### PR TITLE
[codex] publish release assets and lightweight ghcr image

### DIFF
--- a/.github/workflows/build-matrix.yaml
+++ b/.github/workflows/build-matrix.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 jobs:
@@ -76,3 +79,47 @@ jobs:
         with:
           name: skillet-checksums
           path: dist/SHA256SUMS
+
+  github-release:
+    if: github.event_name == 'release'
+    needs:
+      - build
+      - checksums
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download workflow artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          path: .artifacts
+
+      - name: Stage release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          shopt -s nullglob
+
+          for dir in .artifacts/skillet-*; do
+            for file in "$dir"/skillet-* "$dir"/*.exe; do
+              [[ -f "$file" ]] || continue
+              cp "$file" release-assets/
+            done
+          done
+
+          if [[ -f .artifacts/skillet-checksums/SHA256SUMS ]]; then
+            cp .artifacts/skillet-checksums/SHA256SUMS release-assets/
+          fi
+
+          if [[ -f .artifacts/skillet-ubuntu-latest/build-manifest.json ]]; then
+            cp .artifacts/skillet-ubuntu-latest/build-manifest.json release-assets/
+          fi
+
+          ls -1 release-assets
+
+      - name: Upload assets to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" release-assets/* --clobber

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -53,6 +53,9 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --tag "$IMAGE:${{ steps.vars.outputs.tag }}" \
+            --label org.opencontainers.image.source="https://github.com/${{ github.repository }}" \
+            --label org.opencontainers.image.revision="${{ github.sha }}" \
+            --label org.opencontainers.image.version="${{ steps.vars.outputs.tag }}" \
             --push \
             .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
 # syntax=docker/dockerfile:1.7
-FROM alpine:3.22
-
-ARG TARGETARCH
+FROM alpine:3.22 AS runtime-base
 
 RUN apk add --no-cache libstdc++ libgcc
 
-COPY dist/skillet-linux-x64-musl /tmp/skillet-linux-x64-musl
-COPY dist/skillet-linux-arm64-musl /tmp/skillet-linux-arm64-musl
+FROM runtime-base AS runtime-amd64
 
-RUN set -eux; \
-  case "$TARGETARCH" in \
-    amd64) cp /tmp/skillet-linux-x64-musl /usr/local/bin/skillet ;; \
-    arm64) cp /tmp/skillet-linux-arm64-musl /usr/local/bin/skillet ;; \
-    *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
-  esac; \
-  chmod +x /usr/local/bin/skillet; \
-  rm -f /tmp/skillet-linux-x64-musl /tmp/skillet-linux-arm64-musl
+COPY --chmod=755 dist/skillet-linux-x64-musl /usr/local/bin/skillet
 
-ENTRYPOINT ["/usr/local/bin/skillet"]
+FROM runtime-base AS runtime-arm64
+
+COPY --chmod=755 dist/skillet-linux-arm64-musl /usr/local/bin/skillet
+
+ARG TARGETARCH
+FROM runtime-${TARGETARCH}
+
+RUN ln -s /usr/local/bin/skillet /usr/local/bin/sklt
+
+ENTRYPOINT ["/usr/local/bin/sklt"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Skillet installs, discovers, and updates `SKILL.md`-based skills across supporte
 
 | Method | Command / Source | Status |
 | --- | --- | --- |
-| Binary release | Download from GitHub Releases | Planned |
+| Binary release | Download from GitHub Releases | Configured |
 | Homebrew | `brew install skillet` | Configured |
 | Chocolatey | `choco install skillet` | Configured |
 | winget | `winget install skillet` | Configured |

--- a/docs/distribution/chocolatey.md
+++ b/docs/distribution/chocolatey.md
@@ -8,6 +8,8 @@ Skillet ships a Chocolatey package for Windows CLI installs.
 2. Render `packaging/chocolatey/` from `SHA256SUMS`.
 3. Build and push the `.nupkg` with `choco pack` and `choco push`.
 
+GitHub releases now receive the compiled `sklt` binaries plus `SHA256SUMS` from `.github/workflows/build-matrix.yaml`, so Chocolatey packaging can reuse the same published artifacts.
+
 ## Commands
 
 ```bash

--- a/docs/distribution/docker.md
+++ b/docs/distribution/docker.md
@@ -1,6 +1,6 @@
 # Docker Distribution
 
-Skillet publishes a Linux musl-based container image with `skillet` as the entrypoint.
+Skillet publishes a lightweight Linux musl-based GHCR image with `sklt` as the entrypoint.
 
 ## Build Inputs
 
@@ -27,6 +27,12 @@ docker buildx build \
   --push .
 ```
 
+Run it directly:
+
+```bash
+docker run --rm ghcr.io/echohello-dev/skillet:<version> --help
+```
+
 Repository automation:
 
-- `.github/workflows/docker-image.yaml` publishes `ghcr.io/<owner>/skillet:<version>` on release.
+- `.github/workflows/docker-image.yaml` publishes a multi-arch lightweight image to `ghcr.io/<owner>/skillet:<version>` and updates `:latest` for tagged releases.

--- a/docs/distribution/homebrew.md
+++ b/docs/distribution/homebrew.md
@@ -6,7 +6,7 @@ Skillet ships a Homebrew formula for direct `brew install` on macOS.
 
 1. Build release artifacts and checksums.
 2. Render `packaging/homebrew/skillet.rb` from checksums.
-3. Publish GitHub release assets for the same version.
+3. Publish GitHub release assets for the same version. `.github/workflows/build-matrix.yaml` now uploads the compiled binaries, `SHA256SUMS`, and `build-manifest.json` to the tagged GitHub release automatically.
 4. Push formula update to the tap repository.
 
 ## Commands

--- a/docs/distribution/winget.md
+++ b/docs/distribution/winget.md
@@ -9,6 +9,8 @@ Skillet ships a winget manifest set for Windows installs.
 3. Validate manifests with `winget validate`.
 4. Submit manifests to [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
 
+The release workflow also attaches the Windows binary and `SHA256SUMS` to the matching GitHub release, which gives winget a stable download source.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary
This change makes tagged Skillet releases directly usable without requiring downstream packagers to rebuild artifacts themselves. GitHub releases now receive the compiled `sklt` binaries, checksum file, and build manifest, and the existing GHCR publish flow now produces a lightweight multi-arch image that runs `sklt` directly.

Previously, Release Please created GitHub releases but those releases did not include runnable binaries, which made the advertised binary distribution path incomplete and forced package managers to depend on separately rebuilt artifacts. The Docker publish workflow also pushed an image, but the container entrypoint and image structure were not optimized around the `sklt` command users expect to run.

The root cause was that the build matrix workflow only uploaded internal workflow artifacts, not release assets, and the container image copied both Linux binaries into a single final stage before selecting one at runtime. This update adds a release-only upload job in `.github/workflows/build-matrix.yaml`, restructures `Dockerfile` so each architecture copies only its own musl binary into the final image, switches the container entrypoint to `sklt`, and adds OCI metadata labels in `.github/workflows/docker-image.yaml`. The README and distribution docs were updated to reflect that GitHub releases and GHCR are now configured distribution channels.

## Validation
- `mise run ci`
- `mise run docker-smoke`