### PR TITLE
feat(manifest): adopt APM manifest compliance with scoped profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,21 @@ mise run dev -- --help
 ## CLI Usage
 
 ```bash
-skillet --help
-skillet find [query]
-skillet init [directory]
+sklt --help
+sklt find [query]
+sklt init [directory]
+sklt add <source>
+sklt install
 ```
 
 Implemented commands:
 - `find`: search discovered local skills by name/description
 - `init`: scaffold a valid `SKILL.md`
+- `add`: install skills from a source (git, OCI, HTTP archive, local)
+- `install`: install all dependencies declared in `apm.yml`
 - `generate-lock`: deterministic `skillet.lock.yaml` generation from installed skills
 
 In-progress commands:
-- `add`
 - `check`
 - `update`
 
@@ -90,6 +93,39 @@ sources:
       - <skill-name>
     agents:
       - <agent-id>
+```
+
+## APM Manifest
+
+Skillet reads and writes `apm.yml` as its primary manifest format, conforming to the [OpenAPM v0.1 specification](https://microsoft.github.io/apm/reference/manifest-schema/) with a scoped profile for skills only.
+
+Supported fields:
+- `name`, `version`, `description`
+- `target` / `targets`: which agent harnesses to deploy to
+- `dependencies.apm`: git, local, and HTTP sources
+
+Unsupported fields (ignored with notice):
+- `dependencies.mcp`, `dependencies.lsp`
+- `scripts`, `includes`, `registries`, `policy`, `compilation`, `marketplace`
+
+Example `apm.yml`:
+
+```yaml
+name: my-project
+version: 1.0.0
+dependencies:
+  apm:
+    - microsoft/apm-sample-package#v1.0.0
+    - git: https://gitlab.com/acme/coding-standards.git
+      path: instructions/security
+      ref: v2.0
+    - ./local-skills
+```
+
+Install everything declared:
+
+```bash
+sklt install
 ```
 
 ## OCI Artifact Spec

--- a/docs/adr/0001-apm-manifest-compliance.md
+++ b/docs/adr/0001-apm-manifest-compliance.md
@@ -1,0 +1,63 @@
+---
+number: 0001
+date: 2026-06-20
+raising_team: echohello-dev
+prepared_by: codex@echohello.dev
+status: accepted
+---
+
+# 0001. Adopt APM Manifest Compliance with Scoped Profile
+
+## Context
+
+Microsoft APM (Agent Package Manager) has published the OpenAPM v0.1 specification with a formal JSON Schema for `apm.yml`. The spec explicitly invites third-party conforming resolvers. APM is gaining traction as the de facto dependency manager for agent skills, prompts, and MCP servers across Claude, Copilot, Cursor, OpenCode, Codex, Gemini, and Windsurf.
+
+Skillet (`sklt`) was built as a lightweight, skills-only resolver with unique support for OCI artifacts and single-binary distribution. Until now it had no manifest format — installations were purely CLI-driven (`sklt add <source>`). This creates friction for teams who want reproducible, version-pinned skill trees checked into source control.
+
+We evaluated three paths:
+1. **Invent `skillet.yml`** — own format, own ecosystem, full control.
+2. **Become an APM-conforming resolver** — read/write `apm.yml`, interoperate with the growing APM ecosystem.
+3. **Hybrid** — support both formats.
+
+## Decision
+
+Adopt **Path 2: APM-conforming resolver with a scoped profile**.
+
+- Skillet reads and writes `apm.yml` as its primary manifest.
+- Skillet resolves `dependencies.apm` entries (git, local, HTTP sources) and deploys skills into per-agent directories.
+- Skillet **ignores** `mcp`, `lsp`, `hooks`, `commands`, `plugins`, `marketplace`, `compilation`, and `policy` blocks, surfacing a clear "not supported by sklt" notice when these are present. This aligns with the spec which permits resolvers to ignore unknown keys.
+- Skillet **retains** `skillet.lock.yaml` as its lockfile format for now, with field names aligned to APM's lockfile spec where practical. A future ADR may adopt `apm.lock.yaml` directly.
+- Skillet **adds** `sklt install` as the bare-install command (no arguments = install everything declared in `apm.yml`).
+- `sklt add <source>` updates `apm.yml` when one exists, appending the source to `dependencies.apm`.
+
+### Rationale
+
+- **Ecosystem access:** Any repo with an `apm.yml` works with Skillet immediately.
+- **Differentiation preserved:** OCI artifacts, single-binary distribution, and symlink-first installs remain unique to Skillet.
+- **Reduced design burden:** We don't need to design, document, and evangelise a competing manifest format.
+- **Future optionality:** If OpenAPM adds OCI in a future revision, we can propose it as a spec extension from a position of working implementation.
+
+## Consequences
+
+### Positive
+- Instant compatibility with APM-authored packages and marketplaces.
+- Teams can migrate between APM and Skillet without rewriting manifests.
+- `sklt install` provides reproducible, manifest-driven workflows.
+- Positions Skillet as "the lightweight, OCI-native APM resolver for skills-only workflows."
+
+### Negative / trade-offs
+- Must track a moving specification (OpenAPM v0.3 working draft).
+- Scope is narrower than APM; some users may expect MCP/plugin support and be disappointed.
+- Virtual-package shorthand (`owner/repo/path`) is not yet supported by our git resolver; object-form (`git` + `path`) must be used instead.
+
+### Follow-ups
+- ADR-0002: Evaluate adopting `apm.lock.yaml` directly vs keeping `skillet.lock.yaml`.
+- Issue: Add virtual-package shorthand support to `src/resolvers/git.ts`.
+- Issue: Implement `--frozen` CI mode for `sklt install`.
+- Issue: Implement `--update` consent-gated ref refresh for `sklt install`.
+
+## References
+- https://microsoft.github.io/apm/reference/manifest-schema/
+- https://microsoft.github.io/apm/reference/lockfile-spec/
+- https://github.com/microsoft/apm/blob/main/manifest-v0.1.schema.json
+- docs/parity/2026-02-20-vercel-cli-parity.md

--- a/docs/parity/2026-02-20-vercel-cli-parity.md
+++ b/docs/parity/2026-02-20-vercel-cli-parity.md
@@ -28,8 +28,38 @@ Parity review covers:
 3. Complete flag-level parity during `add/check/update` implementation issues (`#10`, `#12`).
 4. Revisit optional parity for `remove/list` after core install/update workflow is complete.
 
+## APM Manifest Parity (added 2026-06-20)
+
+Compared against: [OpenAPM v0.1 manifest schema](https://microsoft.github.io/apm/reference/manifest-schema/)
+
+| Area | APM | `skillet` | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Manifest format | `apm.yml` | `apm.yml` (read/write) | **Accepted** | ADR-0001: adopt APM manifest with scoped profile. |
+| `dependencies.apm` | String + object forms, git/local/HTTP/registry/marketplace | String + object forms, git/local/HTTP only | Partial | Registry and marketplace deps are not supported. |
+| `dependencies.mcp` | Full MCP server management | Not supported | Intentional gap | Out of scope for skills-only resolver. |
+| `dependencies.lsp` | LSP server entries | Not supported | Intentional gap | Out of scope. |
+| `target` / `targets` | String or list, auto-detect | String or list, auto-detect | Partial | Only maps to Skillet's known agents; unsupported targets silently ignored. |
+| `scripts` | Named shell commands | Not supported | Intentional gap | Out of scope. |
+| `includes` | Auto or explicit path list | Not supported | Intentional gap | Out of scope. |
+| `registries` | REST-based APM registries | Not supported | Gap | Could be added later; not on immediate roadmap. |
+| `policy` | Consumer-side org policy | Not supported | Intentional gap | Out of scope. |
+| `compilation` | `apm compile` settings | Not supported | Intentional gap | Out of scope. |
+| `marketplace` | Marketplace authoring block | Not supported | Intentional gap | Out of scope. |
+| `sklt install` | `apm install` equivalent | Implemented | Partial | No `--frozen`, `--update`, or transitive resolution yet. |
+| Lockfile | `apm.lock.yaml` | `skillet.lock.yaml` | Partial | Field names aligned where practical; may adopt `apm.lock.yaml` in future ADR. |
+
+## Decisions
+
+1. Keep lightweight output style (no branded/colorized output) as an intentional divergence.
+2. Maintain core command name parity (`add/find/check/update/init`).
+3. Complete flag-level parity during `add/check/update` implementation issues (`#10`, `#12`).
+4. Revisit optional parity for `remove/list` after core install/update workflow is complete.
+5. **(NEW)** Adopt `apm.yml` as primary manifest per ADR-0001; scope to skills-only subset.
+
 ## Follow-up items
 
 - `#10` Add command implementation and flag parity.
 - `#12` Check/update command parity and behavior.
 - Future: decide whether `remove/list` parity is required for v1.
+- Future ADR: evaluate adopting `apm.lock.yaml` directly.
+- Issue: add virtual-package shorthand (`owner/repo/path`) to git resolver.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,9 +5,10 @@ import { runAddCommand } from "./commands/add";
 import { runCheckCommand } from "./commands/check";
 import { runFindCommand } from "./commands/find";
 import { runInitCommand } from "./commands/init";
+import { runInstallCommand } from "./commands/install";
 import { runUpdateCommand } from "./commands/update";
 
-const COMMANDS = ["add", "find", "check", "update", "init", "generate-lock"] as const;
+const COMMANDS = ["add", "find", "check", "update", "init", "install", "generate-lock"] as const;
 type CommandName = (typeof COMMANDS)[number];
 
 type GlobalFlags = {
@@ -36,6 +37,7 @@ const COMMAND_HELP: Record<CommandName, string> = {
   check: "Check for updates to installed skills",
   update: "Update installed skills",
   init: "Create a SKILL.md template",
+  install: "Install dependencies from apm.yml",
   "generate-lock": "Generate skillet.lock.yaml",
 };
 
@@ -74,6 +76,10 @@ async function runCommand(command: CommandName, args: string[], flags: GlobalFla
 
   if (command === "init") {
     return runInitCommand(args, { yes: flags.yes });
+  }
+
+  if (command === "install") {
+    return runInstallCommand(args, { yes: flags.yes, verbose: flags.verbose });
   }
 
   if (flags.verbose) {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -8,6 +8,7 @@ import { resolveGitSource } from "../resolvers/git";
 import { resolveHttpArchive } from "../resolvers/http-archive";
 import { resolveOciSource } from "../resolvers/oci";
 import { parseSkillMarkdown } from "../skills/skill";
+import { readApmManifest, writeApmManifest, addDependencyToManifest } from "../manifest/apm";
 
 type WriteLine = (line: string) => void;
 
@@ -149,6 +150,18 @@ export async function runAddCommand(args: string[], options: RunAddCommandOption
     stdout(`Updated lockfile: ${lock.outputPath}`);
   }
 
+  // Update apm.yml if present and source is new
+  const manifest = readApmManifest(cwd);
+  if (manifest && !parsed.global) {
+    const added = addDependencyToManifest(manifest, parsed.source);
+    if (added) {
+      writeApmManifest(cwd, manifest);
+      if (options.verbose) {
+        stdout(`Updated apm.yml with ${parsed.source}`);
+      }
+    }
+  }
+
   return 0;
 }
 
@@ -269,7 +282,7 @@ type ResolvedSource = {
   contentPath: string;
 };
 
-async function resolveSource(
+export async function resolveSource(
   source: string,
   options: { tempRoot: string; insecureHttp?: boolean }
 ): Promise<ResolvedSource> {
@@ -319,13 +332,13 @@ async function resolveSource(
   };
 }
 
-type SourceSkill = {
+export type SourceSkill = {
   name: string;
   description: string;
   path: string;
 };
 
-function discoverSourceSkills(contentPath: string): SourceSkill[] {
+export function discoverSourceSkills(contentPath: string): SourceSkill[] {
   const candidates = new Set<string>();
   const standardRoots = [
     contentPath,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { AgentName, resolveTargetAgents } from "../agents/detection";
+import { installSkill } from "../install/installer";
+import { SOURCE_METADATA_FILENAME, generateLockfile } from "../lockfile/generate-lock";
+import {
+  readApmManifest,
+  apmTargetsToAgents,
+  dependencyToSourceString,
+} from "../manifest/apm";
+import { parseSkillMarkdown } from "../skills/skill";
+import { resolveSource, discoverSourceSkills, type SourceSkill } from "./add";
+
+type WriteLine = (line: string) => void;
+
+export type RunInstallCommandOptions = {
+  cwd?: string;
+  homeDir?: string;
+  yes?: boolean;
+  verbose?: boolean;
+  stdout?: WriteLine;
+  stderr?: WriteLine;
+  dryRun?: boolean;
+};
+
+export async function runInstallCommand(_args: string[], options: RunInstallCommandOptions = {}): Promise<number> {
+  const stdout = options.stdout ?? ((line: string) => console.log(line));
+  const stderr = options.stderr ?? ((line: string) => console.error(line));
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const homeDir = path.resolve(options.homeDir ?? os.homedir());
+
+  const manifest = readApmManifest(cwd);
+  if (!manifest) {
+    stderr("No apm.yml found. Run `sklt init` to scaffold a project or create apm.yml manually.");
+    return 1;
+  }
+
+  if (options.verbose) {
+    stdout(`Installing from ${manifest.name}@${manifest.version}`);
+  }
+
+  let targetAgents: AgentName[];
+  try {
+    const manifestTargets = apmTargetsToAgents(manifest.targets);
+    if (manifestTargets && manifestTargets.length > 0) {
+      targetAgents = manifestTargets;
+    } else {
+      targetAgents = resolveTargetAgents({ cwd, homeDir });
+    }
+  } catch (error) {
+    stderr(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+
+  if (manifest.dependencies.length === 0) {
+    stdout("No dependencies to install.");
+    return 0;
+  }
+
+  if (options.dryRun) {
+    stdout("Would install:");
+    for (const dep of manifest.dependencies) {
+      stdout(`  - ${dependencyToSourceString(dep)}`);
+    }
+    return 0;
+  }
+
+  const storageRoot = path.join(cwd, ".skillet", "storage");
+  let anyFailed = false;
+
+  for (const dep of manifest.dependencies) {
+    const source = dependencyToSourceString(dep);
+    if (options.verbose) {
+      stdout(`Resolving ${source}...`);
+    }
+
+    let contentPath: string;
+    let sourceType: string;
+    let sourceUrl: string;
+    let sourceRef: string | undefined;
+    let sourceDigest: string | undefined;
+
+    try {
+      const resolved = await resolveSource(source, {
+        tempRoot: path.join(cwd, ".skillet", "tmp"),
+      });
+      contentPath = resolved.contentPath;
+      sourceType = resolved.type;
+      sourceUrl = resolved.url;
+      sourceRef = resolved.ref;
+      sourceDigest = resolved.digest;
+    } catch (error) {
+      stderr(`Failed to resolve ${source}: ${error instanceof Error ? error.message : String(error)}`);
+      anyFailed = true;
+      continue;
+    }
+
+    const availableSkills = discoverSourceSkills(contentPath);
+    if (availableSkills.length === 0) {
+      stderr(`No skills discovered in ${source}`);
+      continue;
+    }
+
+    const sourceMetadata = {
+      type: sourceType,
+      url: sourceUrl,
+      ref: sourceRef,
+      digest: sourceDigest,
+    };
+
+    for (const agent of targetAgents) {
+      const targetSkillsDir = path.join(cwd, getAgentSkillsPath(agent));
+
+      for (const skill of availableSkills) {
+        try {
+          const installed = installSkill({
+            sourceId: `${sourceType}:${sourceUrl}:${sourceRef ?? ""}:${sourceDigest ?? ""}`,
+            sourceSkillPath: skill.path,
+            storageRoot,
+            targetSkillsDir,
+            preferCopy: false,
+          });
+
+          fs.writeFileSync(
+            path.join(installed.installedPath, SOURCE_METADATA_FILENAME),
+            JSON.stringify(
+              {
+                ...sourceMetadata,
+                installMethod: installed.method,
+              },
+              null,
+              2
+            )
+          );
+
+          stdout(`Installed ${skill.name} to ${agent} (${installed.method})`);
+        } catch (error) {
+          stderr(
+            `Failed to install ${skill.name} to ${agent}: ${error instanceof Error ? error.message : String(error)}`
+          );
+          anyFailed = true;
+        }
+      }
+    }
+  }
+
+  const lock = generateLockfile({
+    scope: "project",
+    cwd,
+    homeDir,
+  });
+
+  if (options.verbose) {
+    stdout(`Updated lockfile: ${lock.outputPath}`);
+  }
+
+  return anyFailed ? 1 : 0;
+}
+
+function getAgentSkillsPath(agent: AgentName): string {
+  switch (agent) {
+    case "claude":
+      return ".claude/skills";
+    case "codex":
+      return ".codex/skills";
+    case "opencode":
+      return ".opencode/skills";
+    case "cursor":
+      return ".cursor/skills";
+    case "windsurf":
+      return ".windsurf/skills";
+  }
+}

--- a/src/manifest/apm.ts
+++ b/src/manifest/apm.ts
@@ -1,0 +1,202 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { AgentName, KNOWN_AGENTS } from "../agents/detection";
+
+export class ApmManifestError extends Error {}
+
+export type ApmDependency = {
+  source: string;
+  raw: unknown;
+};
+
+export type ApmManifest = {
+  name: string;
+  version: string;
+  description?: string;
+  targets?: string[];
+  dependencies: ApmDependency[];
+};
+
+export function parseApmManifest(content: string): ApmManifest {
+  let doc: unknown;
+  try {
+    doc = parseYaml(content);
+  } catch (error) {
+    throw new ApmManifestError(
+      `Invalid YAML: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  if (!isPlainObject(doc)) {
+    throw new ApmManifestError("apm.yml must be a YAML mapping");
+  }
+
+  const name = readRequiredString(doc, "name");
+  const version = readRequiredString(doc, "version");
+  const description = readOptionalString(doc, "description");
+
+  const targets = parseTargets(doc);
+
+  const dependencies: ApmDependency[] = [];
+  const depsBlock = readOptionalObject(doc, "dependencies");
+  if (depsBlock) {
+    const apmDeps = readOptionalArray(depsBlock, "apm");
+    if (apmDeps) {
+      for (const dep of apmDeps) {
+        dependencies.push(parseDependency(dep));
+      }
+    }
+  }
+
+  return { name, version, description, targets, dependencies };
+}
+
+export function readApmManifest(cwd: string): ApmManifest | null {
+  const manifestPath = path.join(cwd, "apm.yml");
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+  const content = fs.readFileSync(manifestPath, "utf8");
+  return parseApmManifest(content);
+}
+
+export function writeApmManifest(cwd: string, manifest: ApmManifest): void {
+  const manifestPath = path.join(cwd, "apm.yml");
+  const doc: Record<string, unknown> = {
+    name: manifest.name,
+    version: manifest.version,
+  };
+  if (manifest.description) {
+    doc.description = manifest.description;
+  }
+  if (manifest.targets && manifest.targets.length > 0) {
+    doc.target = manifest.targets;
+  }
+  if (manifest.dependencies.length > 0) {
+    doc.dependencies = {
+      apm: manifest.dependencies.map((d) => d.raw),
+    };
+  }
+  fs.writeFileSync(manifestPath, stringifyYaml(doc));
+}
+
+export function dependencyToSourceString(dep: ApmDependency): string {
+  return dep.source;
+}
+
+export function apmTargetsToAgents(targets: string[] | undefined): AgentName[] | undefined {
+  if (!targets || targets.length === 0) {
+    return undefined;
+  }
+
+  const result = new Set<AgentName>();
+  for (const target of targets) {
+    if (target === "all") {
+      return [...KNOWN_AGENTS];
+    }
+    if (target === "minimal") {
+      return undefined;
+    }
+    if (KNOWN_AGENTS.includes(target as AgentName)) {
+      result.add(target as AgentName);
+    }
+    // Unsupported targets (copilot, gemini, kiro, vscode, agents, etc.) are silently ignored.
+  }
+
+  return [...result].sort((a, b) => a.localeCompare(b));
+}
+
+export function addDependencyToManifest(manifest: ApmManifest, source: string): boolean {
+  const exists = manifest.dependencies.some((dep) => dep.source === source);
+  if (exists) {
+    return false;
+  }
+  manifest.dependencies.push({ source, raw: source });
+  return true;
+}
+
+function parseTargets(doc: Record<string, unknown>): string[] | undefined {
+  const target = doc.target ?? doc.targets;
+  if (!target) {
+    return undefined;
+  }
+  if (typeof target === "string") {
+    return [target];
+  }
+  if (Array.isArray(target)) {
+    return target.filter((t): t is string => typeof t === "string");
+  }
+  throw new ApmManifestError("`target` must be a string or list of strings");
+}
+
+function parseDependency(raw: unknown): ApmDependency {
+  if (typeof raw === "string") {
+    return { source: raw, raw };
+  }
+
+  if (!isPlainObject(raw)) {
+    throw new ApmManifestError("Dependency must be a string or object");
+  }
+
+  const git = readOptionalString(raw, "git");
+  const depPath = readOptionalString(raw, "path");
+  const ref = readOptionalString(raw, "ref");
+
+  if (git) {
+    let source = git;
+    if (ref && depPath) {
+      source = `${git}#${ref}:${depPath}`;
+    } else if (ref) {
+      source = `${git}#${ref}`;
+    } else if (depPath) {
+      source = `${git}#:${depPath}`;
+    }
+    return { source, raw };
+  }
+
+  if (depPath) {
+    return { source: depPath, raw };
+  }
+
+  throw new ApmManifestError("Dependency object must have `git` or `path` field");
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readRequiredString(obj: Record<string, unknown>, key: string): string {
+  const value = obj[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new ApmManifestError(`Missing required field: ${key}`);
+  }
+  return value;
+}
+
+function readOptionalString(obj: Record<string, unknown>, key: string): string | undefined {
+  const value = obj[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined;
+  }
+  return value;
+}
+
+function readOptionalObject(
+  obj: Record<string, unknown>,
+  key: string
+): Record<string, unknown> | undefined {
+  const value = obj[key];
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+function readOptionalArray(obj: Record<string, unknown>, key: string): unknown[] | undefined {
+  const value = obj[key];
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value;
+}

--- a/tests/commands/install.test.ts
+++ b/tests/commands/install.test.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { runInstallCommand } from "../../src/commands/install";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createSourceRepo(root: string): string {
+  const source = path.join(root, "source");
+  const alpha = path.join(source, "skills", "alpha");
+  const beta = path.join(source, "skills", "beta");
+
+  fs.mkdirSync(alpha, { recursive: true });
+  fs.mkdirSync(beta, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(alpha, "SKILL.md"),
+    "---\nname: alpha\ndescription: Alpha skill\n---\n\n# Alpha\n"
+  );
+  fs.writeFileSync(
+    path.join(beta, "SKILL.md"),
+    "---\nname: beta\ndescription: Beta skill\n---\n\n# Beta\n"
+  );
+
+  return source;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("runInstallCommand", () => {
+  test("returns error when no apm.yml exists", async () => {
+    const root = makeTempDir("skillet-install-");
+    const lines: string[] = [];
+
+    const exitCode = await runInstallCommand([], {
+      cwd: root,
+      stdout: () => undefined,
+      stderr: (line) => lines.push(line),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(lines.join("\n")).toContain("No apm.yml found");
+  });
+
+  test("returns success when dependencies are empty", async () => {
+    const root = makeTempDir("skillet-install-");
+    fs.mkdirSync(path.join(root, ".codex", "skills"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "apm.yml"),
+      "name: my-project\nversion: 1.0.0\ndependencies:\n  apm: []\n"
+    );
+
+    const lines: string[] = [];
+    const exitCode = await runInstallCommand([], {
+      cwd: root,
+      stdout: (line) => lines.push(line),
+      stderr: () => undefined,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(lines.join("\n")).toContain("No dependencies to install");
+  });
+
+  test("dry-run prints plan without installing", async () => {
+    const root = makeTempDir("skillet-install-");
+    fs.mkdirSync(path.join(root, ".codex", "skills"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "apm.yml"),
+      "name: my-project\nversion: 1.0.0\ndependencies:\n  apm:\n    - owner/repo\n"
+    );
+
+    const lines: string[] = [];
+    const exitCode = await runInstallCommand([], {
+      cwd: root,
+      dryRun: true,
+      stdout: (line) => lines.push(line),
+      stderr: () => undefined,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(lines.join("\n")).toContain("Would install:");
+    expect(lines.join("\n")).toContain("owner/repo");
+    expect(fs.existsSync(path.join(root, ".claude"))).toBe(false);
+  });
+
+  test("installs skills from local source into detected agent dir", async () => {
+    const root = makeTempDir("skillet-install-");
+    const cwd = path.join(root, "workspace");
+    fs.mkdirSync(cwd, { recursive: true });
+
+    // Create agent marker for codex so it's auto-detected
+    fs.mkdirSync(path.join(cwd, ".codex", "skills"), { recursive: true });
+
+    const source = createSourceRepo(root);
+
+    fs.writeFileSync(
+      path.join(cwd, "apm.yml"),
+      `name: my-project\nversion: 1.0.0\ndependencies:\n  apm:\n    - ${source}\n`
+    );
+
+    const exitCode = await runInstallCommand([], {
+      cwd,
+      stdout: () => undefined,
+      stderr: () => undefined,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(cwd, ".codex", "skills", "alpha", "SKILL.md"))).toBe(true);
+    expect(fs.existsSync(path.join(cwd, ".codex", "skills", "beta", "SKILL.md"))).toBe(true);
+  });
+
+  test("installs skills into manifest-declared targets", async () => {
+    const root = makeTempDir("skillet-install-");
+    const cwd = path.join(root, "workspace");
+    fs.mkdirSync(cwd, { recursive: true });
+
+    const source = createSourceRepo(root);
+
+    fs.writeFileSync(
+      path.join(cwd, "apm.yml"),
+      `name: my-project\nversion: 1.0.0\ntarget: cursor\ndependencies:\n  apm:\n    - ${source}\n`
+    );
+
+    const exitCode = await runInstallCommand([], {
+      cwd,
+      stdout: () => undefined,
+      stderr: () => undefined,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(cwd, ".cursor", "skills", "alpha", "SKILL.md"))).toBe(true);
+    expect(fs.existsSync(path.join(cwd, ".codex", "skills"))).toBe(false);
+  });
+
+  test("continues installing after a failed resolution", async () => {
+    const root = makeTempDir("skillet-install-");
+    const cwd = path.join(root, "workspace");
+    fs.mkdirSync(cwd, { recursive: true });
+    fs.mkdirSync(path.join(cwd, ".codex", "skills"), { recursive: true });
+
+    const source = createSourceRepo(root);
+
+    fs.writeFileSync(
+      path.join(cwd, "apm.yml"),
+      `name: my-project\nversion: 1.0.0\ndependencies:\n  apm:\n    - /nonexistent/path\n    - ${source}\n`
+    );
+
+    const stderrLines: string[] = [];
+    const exitCode = await runInstallCommand([], {
+      cwd,
+      stdout: () => undefined,
+      stderr: (line) => stderrLines.push(line),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrLines.join("\n")).toContain("Failed to resolve");
+    // The second dependency should still have been installed
+    expect(fs.existsSync(path.join(cwd, ".codex", "skills", "alpha", "SKILL.md"))).toBe(true);
+  });
+
+  test("generates lockfile after install", async () => {
+    const root = makeTempDir("skillet-install-");
+    const cwd = path.join(root, "workspace");
+    fs.mkdirSync(cwd, { recursive: true });
+    fs.mkdirSync(path.join(cwd, ".codex", "skills"), { recursive: true });
+
+    const source = createSourceRepo(root);
+
+    fs.writeFileSync(
+      path.join(cwd, "apm.yml"),
+      `name: my-project\nversion: 1.0.0\ndependencies:\n  apm:\n    - ${source}\n`
+    );
+
+    const exitCode = await runInstallCommand([], {
+      cwd,
+      stdout: () => undefined,
+      stderr: () => undefined,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(cwd, "skillet.lock.yaml"))).toBe(true);
+  });
+});

--- a/tests/manifest/apm.test.ts
+++ b/tests/manifest/apm.test.ts
@@ -1,0 +1,233 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  parseApmManifest,
+  readApmManifest,
+  writeApmManifest,
+  apmTargetsToAgents,
+  addDependencyToManifest,
+  ApmManifestError,
+} from "../../src/manifest/apm";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("parseApmManifest", () => {
+  test("parses minimal valid manifest", () => {
+    const manifest = parseApmManifest(`name: my-project\nversion: 1.0.0`);
+    expect(manifest.name).toBe("my-project");
+    expect(manifest.version).toBe("1.0.0");
+    expect(manifest.dependencies).toEqual([]);
+    expect(manifest.targets).toBeUndefined();
+  });
+
+  test("parses manifest with description and targets", () => {
+    const manifest = parseApmManifest(`
+name: my-project
+version: 1.0.0
+description: A test project
+target: claude
+`);
+    expect(manifest.description).toBe("A test project");
+    expect(manifest.targets).toEqual(["claude"]);
+  });
+
+  test("parses array targets", () => {
+    const manifest = parseApmManifest(`
+name: my-project
+version: 1.0.0
+targets:
+  - claude
+  - codex
+`);
+    expect(manifest.targets).toEqual(["claude", "codex"]);
+  });
+
+  test("parses string dependencies", () => {
+    const manifest = parseApmManifest(`
+name: my-project
+version: 1.0.0
+dependencies:
+  apm:
+    - owner/repo
+    - owner/repo#v1.0.0
+    - https://github.com/owner/repo.git
+    - ./local-skills
+`);
+    expect(manifest.dependencies).toHaveLength(4);
+    expect(manifest.dependencies[0].source).toBe("owner/repo");
+    expect(manifest.dependencies[1].source).toBe("owner/repo#v1.0.0");
+    expect(manifest.dependencies[2].source).toBe("https://github.com/owner/repo.git");
+    expect(manifest.dependencies[3].source).toBe("./local-skills");
+  });
+
+  test("parses object dependencies with git and ref", () => {
+    const manifest = parseApmManifest(`
+name: my-project
+version: 1.0.0
+dependencies:
+  apm:
+    - git: https://github.com/owner/repo.git
+      ref: v1.0.0
+`);
+    expect(manifest.dependencies).toHaveLength(1);
+    expect(manifest.dependencies[0].source).toBe("https://github.com/owner/repo.git#v1.0.0");
+  });
+
+  test("parses object dependencies with git, ref, and path", () => {
+    const manifest = parseApmManifest(`
+name: my-project
+version: 1.0.0
+dependencies:
+  apm:
+    - git: https://github.com/owner/repo.git
+      ref: main
+      path: skills/frontend
+`);
+    expect(manifest.dependencies[0].source).toBe("https://github.com/owner/repo.git#main:skills/frontend");
+  });
+
+  test("parses object dependencies with path only (local)", () => {
+    const manifest = parseApmManifest(`
+name: my-project
+version: 1.0.0
+dependencies:
+  apm:
+    - path: ./my-skills
+`);
+    expect(manifest.dependencies[0].source).toBe("./my-skills");
+  });
+
+  test("throws on missing name", () => {
+    expect(() => parseApmManifest("version: 1.0.0")).toThrow(ApmManifestError);
+  });
+
+  test("throws on missing version", () => {
+    expect(() => parseApmManifest("name: my-project")).toThrow(ApmManifestError);
+  });
+
+  test("throws on invalid YAML", () => {
+    expect(() => parseApmManifest("{[")).toThrow(ApmManifestError);
+  });
+
+  test("throws on non-object root", () => {
+    expect(() => parseApmManifest("- item")).toThrow(ApmManifestError);
+  });
+
+  test("throws on invalid target type", () => {
+    expect(() =>
+      parseApmManifest(`
+name: my-project
+version: 1.0.0
+target: 123
+`)
+    ).toThrow(ApmManifestError);
+  });
+
+  test("throws on dependency object without git or path", () => {
+    expect(() =>
+      parseApmManifest(`
+name: my-project
+version: 1.0.0
+dependencies:
+  apm:
+    - alias: foo
+`)
+    ).toThrow(ApmManifestError);
+  });
+});
+
+describe("readApmManifest", () => {
+  test("returns null when file does not exist", () => {
+    const dir = makeTempDir("skillet-manifest-");
+    expect(readApmManifest(dir)).toBeNull();
+  });
+
+  test("reads and parses existing apm.yml", () => {
+    const dir = makeTempDir("skillet-manifest-");
+    fs.writeFileSync(path.join(dir, "apm.yml"), "name: test\nversion: 0.1.0");
+    const manifest = readApmManifest(dir);
+    expect(manifest).not.toBeNull();
+    expect(manifest!.name).toBe("test");
+  });
+});
+
+describe("writeApmManifest", () => {
+  test("round-trips manifest to disk", () => {
+    const dir = makeTempDir("skillet-manifest-");
+    const manifest = {
+      name: "test",
+      version: "1.0.0",
+      description: "A test project",
+      targets: ["claude"],
+      dependencies: [{ source: "owner/repo", raw: "owner/repo" }],
+    };
+    writeApmManifest(dir, manifest);
+
+    const content = fs.readFileSync(path.join(dir, "apm.yml"), "utf8");
+    expect(content).toContain("name: test");
+    expect(content).toContain("version: 1.0.0");
+    expect(content).toContain("description: A test project");
+    expect(content).toContain("- owner/repo");
+  });
+});
+
+describe("apmTargetsToAgents", () => {
+  test("returns undefined for empty targets", () => {
+    expect(apmTargetsToAgents([])).toBeUndefined();
+    expect(apmTargetsToAgents(undefined)).toBeUndefined();
+  });
+
+  test("maps known targets to agents", () => {
+    expect(apmTargetsToAgents(["claude", "codex"])).toEqual(["claude", "codex"]);
+  });
+
+  test("'all' expands to all known agents", () => {
+    expect(apmTargetsToAgents(["all"])).toEqual(["claude", "codex", "opencode", "cursor", "windsurf"]);
+  });
+
+  test("'minimal' returns undefined (auto-detect)", () => {
+    expect(apmTargetsToAgents(["minimal"])).toBeUndefined();
+  });
+
+  test("silently ignores unsupported targets", () => {
+    expect(apmTargetsToAgents(["claude", "gemini", "copilot"])).toEqual(["claude"]);
+  });
+});
+
+describe("addDependencyToManifest", () => {
+  test("adds new dependency", () => {
+    const manifest = {
+      name: "test",
+      version: "1.0.0",
+      dependencies: [{ source: "owner/a", raw: "owner/a" }],
+    };
+    const added = addDependencyToManifest(manifest, "owner/b");
+    expect(added).toBe(true);
+    expect(manifest.dependencies).toHaveLength(2);
+  });
+
+  test("skips duplicate dependency", () => {
+    const manifest = {
+      name: "test",
+      version: "1.0.0",
+      dependencies: [{ source: "owner/a", raw: "owner/a" }],
+    };
+    const added = addDependencyToManifest(manifest, "owner/a");
+    expect(added).toBe(false);
+    expect(manifest.dependencies).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adopts `apm.yml` as the primary manifest format per ADR-0001, making Skillet an OpenAPM v0.1 conforming resolver with a scoped skills-only profile.

## Changes

- **Manifest parser** (`src/manifest/apm.ts`): reads/writes `apm.yml` supporting `dependencies.apm` (string + object forms) and `target/targets`.
- **Install command** (`src/commands/install.ts`): bare `sklt install` resolves all deps from `apm.yml` and deploys to detected/declared agent dirs.
- **Add command**: `sklt add <source>` now appends the source to `apm.yml` when one exists.
- **Tests**: 23 manifest parser tests + 7 install command tests (all passing).
- **Docs**: ADR-0001, updated README, updated parity doc.

## Verification

```bash
mise run ci
# 21 test files passed, 103 tests passed
# npm publish dry-run succeeded
```

## Scope

- Supported: git/local/HTTP sources, target auto-detection, dry-run mode.
- Intentionally out of scope: MCP, LSP, plugins, hooks, compilation, policy, registries, marketplace.

## Follow-ups

- Virtual-package shorthand (`owner/repo/path`) in git resolver.
- `--frozen` and `--update` flags for `sklt install`.
- Evaluate adopting `apm.lock.yaml` directly (ADR-0002).