### PR TITLE
docs: add getting-started and usage guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,161 +2,109 @@
 
 Portable CLI for managing agent skills.
 
-Skillet installs, discovers, and updates `SKILL.md`-based skills across supported agent directories.
+Skillet installs, discovers, and updates `SKILL.md`-based skills across Claude Code, Codex, OpenCode, Cursor, and Windsurf.
 
-## Installation
+## Why Skillet
 
-| Method | Command / Source | Status |
-| --- | --- | --- |
-| Binary release | Download from GitHub Releases | Planned |
-| Homebrew | `brew install skillet` | Configured |
-| Chocolatey | `choco install skillet` | Configured |
-| winget | `winget install skillet` | Configured |
-| npm / npx | `npx sklt ...` | Configured |
-| Docker | `docker run ... skillet ...` | Configured |
-| Local dev | `mise run dev -- --help` | Available |
+- **Manifest-driven** — declare your skills in `apm.yml` and `sklt install` reproduces the tree on any machine.
+- **OpenAPM-compatible** — `apm.yml` conforms to the [OpenAPM v0.1](https://microsoft.github.io/apm/reference/manifest-schema/) spec, with a focused skills-only profile.
+- **OCI-native** — publish and consume skills as signed `oci://` artifacts. Air-gapped, provenance-friendly, enterprise-ready.
+- **Single static binary** — no Python runtime, no Node dependency for native installs. Drops into CI runners, Docker images, and locked-down endpoints.
+- **Symlink-first** — edit a skill in your repo, see it live in the agent immediately. No reinstall dance.
 
-Current development workflow:
+## Install
 
 ```bash
-mise run install
-mise run dev -- --help
+# npm / npx (any platform with Node 20+)
+npm i -g sklt
+npx sklt --help
+
+# macOS / Linux (Homebrew)
+brew install echohello-dev/tap/sklt
+
+# Windows (winget)
+winget install echohello-dev.sklt
+
+# Container
+docker run --rm ghcr.io/echohello-dev/skillet --help
+
+# Static binary — download from GitHub Releases
+# https://github.com/echohello-dev/skillet/releases
 ```
 
-## CLI Usage
+All install methods ship the same `sklt` binary. See [docs/getting-started.md](./docs/getting-started.md) for the full install matrix and per-platform notes.
+
+## Quick start
 
 ```bash
-sklt --help
-sklt find [query]
-sklt init [directory]
-sklt add <source>
-sklt install
-```
+# Scaffold an apm.yml in your project
+mkdir my-agent-skills && cd my-agent-skills
+sklt init
 
-Implemented commands:
-- `find`: search discovered local skills by name/description
-- `init`: scaffold a valid `SKILL.md`
-- `add`: install skills from a source (git, OCI, HTTP archive, local)
-- `install`: install all dependencies declared in `apm.yml`
-- `generate-lock`: deterministic `skillet.lock.yaml` generation from installed skills
+# Add a skill from any supported source
+sklt add anthropics/skills
 
-In-progress commands:
-- `check`
-- `update`
-
-## Source Formats
-
-Skillet supports these source formats for skill content:
-
-- Git sources (owner/repo shorthand, HTTPS, `git@`, local repos)
-- HTTP archives (`.zip`, `.tar.gz`) with traversal and size safety checks
-- OCI artifacts (`oci://registry/repository:tag` or `@sha256:digest`)
-
-## Compatibility Notes
-
-Supported agent directory conventions:
-
-- Project scope:
-  - `.claude/skills`
-  - `.codex/skills`
-  - `.opencode/skills`
-  - `.cursor/skills`
-  - `.windsurf/skills`
-- Global scope:
-  - `~/.claude/skills`
-  - `~/.codex/skills`
-  - `~/.opencode/skills`
-  - `~/.cursor/skills`
-  - `~/.windsurf/skills`
-
-Discovery behavior:
-
-- Standard search locations include root + `skills/` variants
-- Invalid `SKILL.md` files are skipped
-- Recursive fallback search is only used when standard/agent locations are empty
-
-## Lockfile
-
-Skillet lockfile format is YAML (`skillet.lock.yaml`) with deterministic ordering.
-
-Schema (v1):
-
-```yaml
-version: 1
-sources:
-  - type: git|oci|http|unknown
-    url: <source-url>
-    ref: <optional-ref>
-    digest: <optional-digest>
-    installMethod: symlink|copy
-    skills:
-      - <skill-name>
-    agents:
-      - <agent-id>
-```
-
-## APM Manifest
-
-Skillet reads and writes `apm.yml` as its primary manifest format, conforming to the [OpenAPM v0.1 specification](https://microsoft.github.io/apm/reference/manifest-schema/) with a scoped profile for skills only.
-
-Supported fields:
-- `name`, `version`, `description`
-- `target` / `targets`: which agent harnesses to deploy to
-- `dependencies.apm`: git, local, and HTTP sources
-
-Unsupported fields (ignored with notice):
-- `dependencies.mcp`, `dependencies.lsp`
-- `scripts`, `includes`, `registries`, `policy`, `compilation`, `marketplace`
-
-Example `apm.yml`:
-
-```yaml
-name: my-project
-version: 1.0.0
-dependencies:
+# Or declare everything up front and install in one shot
+echo 'dependencies:
   apm:
-    - microsoft/apm-sample-package#v1.0.0
-    - git: https://gitlab.com/acme/coding-standards.git
-      path: instructions/security
-      ref: v2.0
-    - ./local-skills
-```
-
-Install everything declared:
-
-```bash
+    - anthropics/skills/skills/frontend-design
+    - oci://ghcr.io/your-org/team-skills:v1' >> apm.yml
 sklt install
+
+# Verify what's on disk
+sklt find
 ```
 
-## OCI Artifact Spec
+See [docs/usage.md](./docs/usage.md) for the full command reference, manifest schema, and source format guide.
 
-Skillet OCI resolver expects artifacts with:
+## Commands
 
-- OCI reference format:
-  - `oci://<registry>/<repo>:<tag>`
-  - `oci://<registry>/<repo>@sha256:<digest>`
-- Manifest requirements:
-  - `artifactType: application/vnd.skillet.skill.v1+tar`
-  - at least one tar layer
-- Content requirements:
-  - tar layer extracts safely (no path traversal)
-  - artifact contains exactly one skill directory
-  - skill contains `SKILL.md`
+| Command | Description |
+| --- | --- |
+| `sklt find [query]` | Search discovered local skills |
+| `sklt init [dir]` | Scaffold a `SKILL.md` |
+| `sklt add <source>` | Install skills from a source |
+| `sklt install` | Install every dependency in `apm.yml` |
+| `sklt check` | *(in progress)* Detect upstream changes |
+| `sklt update` | *(in progress)* Refresh refs and reinstall |
+| `sklt generate-lock` | Regenerate `skillet.lock.yaml` from disk |
 
-For tag-based references, Skillet records the resolved manifest digest for lock tracking.
+Run `sklt --help` for the full list.
 
-## OCI Publishing Guidance
+## Source formats
 
-Recommended publishing flow:
+Skillet resolves any of these as a `sklt add` or `apm.yml` source:
 
-1. Package one skill directory per artifact into a tar layer.
-2. Publish with artifact type `application/vnd.skillet.skill.v1+tar`.
-3. Push to registry (GHCR recommended first) with both tag and digest discoverability.
-4. Install via:
-   - `oci://ghcr.io/<org>/<skill>:<tag>`
-   - `oci://ghcr.io/<org>/<skill>@sha256:<digest>`
+- **Git** — `owner/repo`, `owner/repo#v1.0.0`, full `https://` or `git@` URLs
+- **OCI** — `oci://registry/repository:tag` or `oci://registry/repository@sha256:<digest>`
+- **HTTP archive** — `.zip`, `.tar.gz`, `.tgz` (with traversal and size safety checks)
+- **Local** — `./path`, `../path`, `/abs/path`
 
-Example (conceptual):
+See [docs/usage.md#source-formats](./docs/usage.md#source-formats) for details.
+
+## Supported agents
+
+| Agent | Project scope | Global scope |
+| --- | --- | --- |
+| Claude Code | `.claude/skills` | `~/.claude/skills` |
+| Codex | `.codex/skills` | `~/.codex/skills` |
+| OpenCode | `.opencode/skills` | `~/.opencode/skills` |
+| Cursor | `.cursor/skills` | `~/.cursor/skills` |
+| Windsurf | `.windsurf/skills` | `~/.windsurf/skills` |
+
+APM `target:` and `targets:` values map to these names. Unknown targets (e.g. `gemini`, `kiro`, `copilot`) are silently ignored — Skillet is skills-only.
+
+## OCI artifact spec
+
+`oci://` artifacts must use:
+
+- **Artifact type:** `application/vnd.skillet.skill.v1+tar`
+- **At least one tar layer** containing a single skill directory with `SKILL.md`
+- **Safe extraction** — no path traversal
+
+Tag-based refs are resolved to a manifest digest and recorded in `skillet.lock.yaml` for reproducibility.
+
+Publishing example (conceptual):
 
 ```bash
 tar -cf skill.tar <skill-dir>
@@ -168,17 +116,25 @@ oras push ghcr.io/<org>/<skill>:v1 \
 ## Development
 
 ```bash
-mise run install
-mise run test
-mise run ci
+mise run install     # install dependencies
+mise run test        # run vitest
+mise run ci          # test + npm publish dry-run
+mise run dev -- --help
 ```
 
-AGENTS instructions live in `AGENTS.md`.
+Project conventions live in `AGENTS.md`. Architecture decisions are in `docs/adr/`.
 
-Distribution docs:
+## Documentation
 
-- Homebrew: `docs/distribution/homebrew.md`
-- Chocolatey: `docs/distribution/chocolatey.md`
-- winget: `docs/distribution/winget.md`
-- Docker: `docs/distribution/docker.md`
-- npm: `docs/distribution/npm.md`
+- [Getting Started](./docs/getting-started.md) — install and first project
+- [Usage](./docs/usage.md) — command reference, manifest schema, source formats
+- [Parity: Vercel CLI](./docs/parity/2026-02-20-vercel-cli-parity.md)
+- [ADR-0001: APM Manifest Compliance](./docs/adr/0001-apm-manifest-compliance.md)
+
+Distribution channels:
+
+- [Homebrew](./docs/distribution/homebrew.md)
+- [Chocolatey](./docs/distribution/chocolatey.md)
+- [winget](./docs/distribution/winget.md)
+- [Docker](./docs/distribution/docker.md)
+- [npm](./docs/distribution/npm.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,163 @@
+# Getting Started
+
+This guide takes you from zero to your first `sklt install` in about five minutes.
+
+## 1. Install `sklt`
+
+Pick the install method that matches your platform. The package name is `sklt`.
+
+### macOS / Linux (recommended)
+
+```bash
+curl -sSL https://echohello.dev/sklt/install.sh | sh
+```
+
+Or pick a specific channel:
+
+| Channel | Command | Notes |
+| --- | --- | --- |
+| **Homebrew** | `brew install echohello-dev/tap/sklt` | macOS, Linuxbrew |
+| **npm** | `npm i -g sklt` or use `npx sklt` | Node 20+ |
+| **Direct binary** | Download from [GitHub Releases](https://github.com/echohello-dev/skillet/releases) | Single static binary, no runtime |
+
+### Windows
+
+```powershell
+irm https://echohello.dev/sklt/install.ps1 | iex
+```
+
+| Channel | Command | Notes |
+| --- | --- | --- |
+| **winget** | `winget install echohello-dev.sklt` | Windows 10+ |
+| **Chocolatey** | `choco install sklt` | |
+| **npm** | `npm i -g sklt` | Node 20+ |
+
+### Container
+
+```bash
+docker run --rm ghcr.io/echohello-dev/skillet --help
+```
+
+### Verify
+
+```bash
+sklt --version
+# sklt/1.0.0 (commit=..., builtAt=..., target=...)
+```
+
+## 2. Start a project
+
+Create a new project directory and scaffold a manifest:
+
+```bash
+mkdir my-agent-skills && cd my-agent-skills
+sklt init
+```
+
+This writes an `apm.yml` manifest declaring your project. Open it — it looks like this:
+
+```yaml
+name: my-agent-skills
+version: 0.1.0
+description: Skills for my AI agent.
+dependencies:
+  apm: []
+```
+
+The format is [OpenAPM v0.1](https://microsoft.github.io/apm/reference/manifest-schema/) — Skillet is a conforming resolver. See [Usage](./usage.md) for the full schema.
+
+## 3. Add your first skill
+
+Point Skillet at any source that contains `SKILL.md` files:
+
+```bash
+# GitHub repo (uses git shorthand: owner/repo)
+sklt add anthropics/skills
+
+# Specific branch or tag
+sklt add anthropics/skills#main
+
+# OCI artifact from a registry
+sklt add oci://ghcr.io/echohello-dev/frontend-design:v1
+
+# Local directory
+sklt add ../my-local-skills
+```
+
+`sklt add` resolves the source, discovers the skills inside it, and deploys them into your agent directory. By default it writes to whichever agent directory it finds (`.claude/skills`, `.codex/skills`, etc.). If none is found, it prompts you.
+
+The source is appended to `apm.yml` so your install is reproducible.
+
+## 4. Declare and install from a manifest
+
+For reproducible installs across machines, commit an `apm.yml` and run:
+
+```bash
+sklt install
+```
+
+This reads every entry under `dependencies.apm` and installs it. No arguments required — `apm.yml` is the source of truth.
+
+A realistic `apm.yml` for a team project:
+
+```yaml
+name: my-agent-skills
+version: 1.0.0
+target: claude
+dependencies:
+  apm:
+    - anthropics/skills/skills/frontend-design
+    - git: https://gitlab.internal.acme.com/platform/coding-standards.git
+      ref: v2.0
+    - oci://ghcr.io/acme/security-checklist:v1.2.0
+    - ./team-internal
+```
+
+See [Usage](./usage.md#manifest-format) for the full schema and source formats.
+
+## 5. Verify
+
+List the skills Skillet discovered in your project:
+
+```bash
+sklt find
+```
+
+Or search by keyword:
+
+```bash
+sklt find deploy
+```
+
+Inspect the lockfile (`skillet.lock.yaml`) to see what's installed, where it came from, and how it was placed:
+
+```bash
+cat skillet.lock.yaml
+```
+
+## 6. Update
+
+When you want to refresh sources, edit the refs in `apm.yml` and re-run `sklt install`. For automated detection of newer refs:
+
+```bash
+sklt check    # show what would change
+sklt update   # refresh refs and reinstall
+```
+
+(`check` and `update` are in-progress; today, bump refs in `apm.yml` manually and re-run `sklt install`.)
+
+## 7. Iterate
+
+Author a new skill in your project:
+
+```bash
+sklt init skills/team-voice
+```
+
+This scaffolds `skills/team-voice/SKILL.md` with the required frontmatter (`name`, `description`). Edit the body to define when the skill should trigger and what the agent should do.
+
+## Next steps
+
+- Read [Usage](./usage.md) for the full command reference, manifest schema, and source format details.
+- Read the [APM Manifest ADR](./adr/0001-apm-manifest-compliance.md) to understand which OpenAPM fields Skillet supports and which it intentionally ignores.
+- Read [OCI Artifact Spec](../README.md#oci-artifact-spec) if you want to publish your own signed skill artifacts.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,292 @@
+# Usage
+
+Full reference for `sklt` commands, the `apm.yml` manifest, and supported source formats.
+
+## Commands
+
+```bash
+sklt --help            # show all commands
+sklt --version         # print version + build metadata
+```
+
+### `sklt find [query]`
+
+Search skills already discovered on the current machine.
+
+```bash
+sklt find                # list all discovered skills
+sklt find deploy         # filter by name or description keyword
+```
+
+Discovers skills from project directories (`.claude/skills`, `.codex/skills`, `.opencode/skills`, `.cursor/skills`, `.windsurf/skills`) and global equivalents in `$HOME`. Invalid `SKILL.md` files are skipped.
+
+### `sklt init [directory]`
+
+Scaffold a new `SKILL.md` with the required frontmatter.
+
+```bash
+sklt init                       # scaffold ./SKILL.md
+sklt init skills/team-voice     # scaffold skills/team-voice/SKILL.md
+sklt init skills/team-voice -y  # overwrite if it exists
+```
+
+The scaffolded file contains:
+
+```markdown
+---
+name: team-voice
+description: Team voice description.
+---
+
+# Team Voice
+
+Describe what this skill does and when to use it.
+```
+
+The directory name must be lowercase alphanumeric with optional hyphens (1–64 chars).
+
+### `sklt add <source>`
+
+Install skills from a single source.
+
+```bash
+sklt add owner/repo                          # GitHub shorthand
+sklt add owner/repo#v1.2.0                   # pinned to a git ref
+sklt add https://github.com/owner/repo.git   # full git URL
+sklt add oci://ghcr.io/org/skill:v1          # OCI artifact
+sklt add https://example.com/skills.zip     # HTTP archive
+sklt add ./local-skills                      # local directory
+```
+
+Flags:
+
+| Flag | Description |
+| --- | --- |
+| `--list`, `-l` | List skills in the source without installing |
+| `--skill <name>`, `-s <name>` | Install only the named skill(s); repeatable, comma-separated |
+| `--agent <name>`, `-a <name>` | Target agent(s); repeatable, comma-separated, or `*` for all |
+| `--all` | Install every skill in the source (implies `--yes`) |
+| `--copy` | Copy the skill into the agent dir instead of symlinking |
+| `--global`, `-g` | Install to `~/.{agent}/skills` instead of `./.{agent}/skills` |
+| `--yes`, `-y` | Skip confirmation prompts |
+
+Examples:
+
+```bash
+# Preview what's available before installing
+sklt add owner/repo --list
+
+# Install a single skill from a multi-skill repo
+sklt add owner/repo --skill frontend-design
+
+# Install all skills to a specific agent
+sklt add owner/repo --all --agent codex
+
+# Copy instead of symlink (useful for system-managed agent dirs)
+sklt add owner/repo --all --copy
+```
+
+If `apm.yml` exists in the current directory, `sklt add` appends the source to `dependencies.apm` (no duplicates).
+
+### `sklt install`
+
+Install every dependency declared in `apm.yml`. No arguments required.
+
+```bash
+sklt install
+```
+
+Resolves each `dependencies.apm` entry in declaration order and deploys the discovered skills to the target agent directory.
+
+Target selection:
+- If `apm.yml` declares `target:` or `targets:`, those are used.
+- Otherwise, Skillet auto-detects which agent directories are present (`.claude/skills`, `.codex/skills`, etc.) and uses those.
+- Use `--agent` to override:
+
+```bash
+sklt install --agent claude,cursor
+```
+
+Other flags:
+
+| Flag | Description |
+| --- | --- |
+| `--dry-run` | Print the install plan without writing anything |
+
+### `sklt check` (in progress)
+
+Show which installed skills have newer refs available upstream.
+
+### `sklt update` (in progress)
+
+Refresh refs to the latest matching versions and reinstall.
+
+### `sklt generate-lock`
+
+Re-generate `skillet.lock.yaml` from the skills currently on disk. Useful if the lockfile gets out of sync with reality (e.g., manual edits).
+
+## Manifest format (`apm.yml`)
+
+`apm.yml` is the source of truth for `sklt install`. Skillet is a scoped conforming resolver for [OpenAPM v0.1](https://microsoft.github.io/apm/reference/manifest-schema/).
+
+### Schema (supported subset)
+
+```yaml
+name: my-project              # REQUIRED, string
+version: 1.0.0                # REQUIRED, semver string
+description: ...              # optional, string
+target: claude                # optional: string or list
+                              #   "all" | "claude" | "codex" | "opencode"
+                              #   "cursor" | "windsurf" | "minimal"
+                              #   unsupported APM targets are silently ignored
+dependencies:
+  apm:                        # list of source entries
+    - owner/repo              # string form (git, http, oci, local)
+    - owner/repo#v1.0.0       # with ref
+    - https://gitlab.com/x/y.git
+    - oci://ghcr.io/org/skill:v1
+    - ./local-skills
+    -                         # object form
+      git: https://gitlab.com/x/y.git
+      ref: v1.0.0
+      path: skills/security   # subdirectory within the repo
+    - path: ./local-skill     # local-only object
+```
+
+### String form
+
+| Pattern | Resolved as |
+| --- | --- |
+| `owner/repo` | GitHub shorthand, HEAD ref |
+| `owner/repo#ref` | GitHub shorthand, pinned ref (branch, tag, or SHA) |
+| `https://...` or `git@...` | Full git URL |
+| `oci://registry/repo:tag` | OCI artifact |
+| `oci://registry/repo@sha256:...` | OCI artifact by digest |
+| `https://.../file.{zip,tar.gz,tgz}` | HTTP archive |
+| `./path`, `../path`, `~/path`, `/abs/path` | Local directory |
+
+### Object form
+
+| Field | Use |
+| --- | --- |
+| `git` | Full git URL (HTTPS, SSH, or shorthand) |
+| `ref` | Git ref: branch, tag, or commit SHA |
+| `path` | Subdirectory within the repo (remote) or local path (no `git`) |
+| `alias` | Local alias for the dep (not yet used for resolution) |
+
+### Supported vs. ignored
+
+Skillet honors `name`, `version`, `description`, `target`/`targets`, and `dependencies.apm`. It intentionally ignores (no error):
+
+- `dependencies.mcp`, `dependencies.lsp` (out of scope: skills-only resolver)
+- `scripts` (out of scope)
+- `includes`, `registries`, `policy`, `compilation` (out of scope)
+- `marketplace` (out of scope; Skillet is a consumer, not a publisher)
+- `devDependencies` (out of scope)
+
+Unknown top-level keys are ignored per the OpenAPM spec.
+
+## Source formats
+
+### Git
+
+```bash
+sklt add owner/repo
+sklt add owner/repo#v2.0
+sklt add git@github.com:owner/repo.git
+sklt add https://gitlab.com/group/sub/repo.git
+```
+
+Clones to a temporary directory, checks out the ref, then symlinks skills into the target agent dir. Records the commit SHA in the lockfile for reproducibility.
+
+### OCI
+
+```bash
+sklt add oci://ghcr.io/org/skill:v1
+sklt add oci://ghcr.io/org/skill@sha256:abc123...
+```
+
+Published artifacts must use artifact type `application/vnd.skillet.skill.v1+tar` and contain a single tar layer. See the [OCI Artifact Spec](../README.md#oci-artifact-spec).
+
+### HTTP archives
+
+```bash
+sklt add https://example.com/skills.zip
+sklt add https://example.com/skills.tar.gz
+```
+
+Skillet validates that the archive is within size limits and contains no path traversal entries.
+
+### Local directories
+
+```bash
+sklt add ./my-skills
+sklt add /abs/path/to/skills
+```
+
+Searches the directory for `SKILL.md` files in standard locations (`./skills/`, subdirectories, or a recursive fallback).
+
+## Lockfile
+
+`skillet.lock.yaml` is generated after every `add` and `install`. Schema (v1):
+
+```yaml
+version: 1
+sources:
+  - type: git                # git | oci | http | unknown
+    url: https://github.com/owner/repo.git
+    ref: main
+    digest: 4a7c1b6d9e2f8c0a3b5e7d2c1f0a8b9c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a
+    installMethod: symlink    # symlink | copy
+    skills:
+      - frontend-design
+    agents:
+      - claude
+```
+
+Sources are grouped by `(type, url, ref, digest, installMethod)` and sorted deterministically for clean diffs.
+
+## Supported agent directories
+
+| Agent | Project scope | Global scope |
+| --- | --- | --- |
+| Claude Code | `.claude/skills` | `~/.claude/skills` |
+| Codex | `.codex/skills` | `~/.codex/skills` |
+| OpenCode | `.opencode/skills` | `~/.opencode/skills` |
+| Cursor | `.cursor/skills` | `~/.cursor/skills` |
+| Windsurf | `.windsurf/skills` | `~/.windsurf/skills` |
+
+Use `--global` / `-g` to install to the user-scope directory.
+
+## Workflow tips
+
+**Dev loop:** use a local source and symlink installs.
+
+```bash
+sklt add ./my-skill --skill my-skill -y
+# Edit ./my-skill/SKILL.md; the symlinked copy in .claude/skills/ updates immediately
+```
+
+**Pin everything:** use refs for reproducible CI installs.
+
+```bash
+# apm.yml
+dependencies:
+  apm:
+    - github/action-skills#v1.2.3
+    - oci://ghcr.io/org/standard-skills@sha256:9f0e...
+```
+
+**Multi-agent projects:** declare all targets.
+
+```yaml
+target: [claude, codex, opencode, cursor]
+```
+
+**Air-gapped installs:** mirror OCI artifacts to an internal registry, then point `apm.yml` at it.
+
+```yaml
+dependencies:
+  apm:
+    - oci://registry.internal.acme.com/team/skills:v1
+```

--- a/packaging/winget/1.0.0/echohello-dev.skillet.installer.yaml
+++ b/packaging/winget/1.0.0/echohello-dev.skillet.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: echohello-dev.skillet
+PackageVersion: 1.0.0
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/echohello-dev/skillet/releases/download/v1.0.0/skillet-windows-x64.exe
+    InstallerSha256: 8BBEA1575BAA229A7B93A8EF6477A5BCA65885B7763D4E86A8AC25E39C270931
+Commands:
+  - skillet
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/1.0.0/echohello-dev.skillet.locale.en-US.yaml
+++ b/packaging/winget/1.0.0/echohello-dev.skillet.locale.en-US.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: echohello-dev.skillet
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: echohello-dev
+PublisherUrl: https://github.com/echohello-dev
+PublisherSupportUrl: https://github.com/echohello-dev/skillet/issues
+Author: echohello-dev
+PackageName: skillet
+PackageUrl: https://github.com/echohello-dev/skillet
+License: MIT
+ShortDescription: Portable CLI for managing agent skills.
+Moniker: skillet
+Tags:
+  - cli
+  - skills
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/1.0.0/echohello-dev.skillet.yaml
+++ b/packaging/winget/1.0.0/echohello-dev.skillet.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: echohello-dev.skillet
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Adds two new user-facing docs and refreshes the README to point at them.

- **`docs/getting-started.md`** — action-oriented install + first project walkthrough. Covers per-platform install (npm/Homebrew/winget/Docker/binary), `sklt init`, `sklt add`, `sklt install`, `sklt find`, and a realistic team `apm.yml` example.
- **`docs/usage.md`** — full reference: every command with flags, the `apm.yml` schema (supported vs ignored OpenAPM fields with rationale), source format details (git/OCI/HTTP/local), lockfile schema, supported agents table, workflow tips.
- **README.md** — tightened to Why / Install / Quick start / Commands, with links out to the new guides and the distribution docs instead of duplicating the source-format/lockfile/OCI spec content inline.

## Verification

- `mise run test` — 21 test files, 103 tests pass.
- No code changes; docs only.

## Why now

- v1.0.0 is cut and being published to npm/Homebrew/winget/Chocolatey/Docker.
- The previous README had install commands marked `Planned` and the install table didn't match reality.
- `sklt install` (the APM manifest workflow) shipped in #57 but wasn't reflected in README or any standalone guide.