### PR TITLE
chore(packaging): fix v1.0.0 winget SHA + manually upload release binaries

### DIFF
--- a/packaging/winget/1.0.0/echohello-dev.skillet.installer.yaml
+++ b/packaging/winget/1.0.0/echohello-dev.skillet.installer.yaml
@@ -4,7 +4,7 @@ Installers:
   - Architecture: x64
     InstallerType: portable
     InstallerUrl: https://github.com/echohello-dev/skillet/releases/download/v1.0.0/skillet-windows-x64.exe
-    InstallerSha256: 8BBEA1575BAA229A7B93A8EF6477A5BCA65885B7763D4E86A8AC25E39C270931
+    InstallerSha256: 35A392614F863447A1FB5FDDA92CA6C5C85CA35E7A41776E111958B433EA4842
 Commands:
   - skillet
 ManifestType: installer


### PR DESCRIPTION
## Summary

- Updates `packaging/winget/1.0.0/echohello-dev.skillet.installer.yaml` with the actual Windows binary SHA from the v1.0.0 release (was a placeholder from a local build).
- Documents that the v1.0.0 release was published with no assets because release-please creates releases using its own App token, and downstream workflows (`release-binaries`, `npm-publish`, `docker-image`) use `GITHUB_TOKEN` which can't upload to App-created releases.
- Manually uploaded all 8 binary assets + SHA256SUMS to the v1.0.0 release via `gh release upload` so the release is actually usable.

## Follow-up needed

A separate PR will fix the release pipeline so this doesn't happen on v1.0.1+. The fix is to either:
1. Configure release-please to create releases using `GITHUB_TOKEN` (requires no App token secret)
2. Or move the binary upload step INTO the release-please workflow itself (same token)