### PR TITLE
chore(npm): rename package to getskillet

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Skillet installs, discovers, and updates `SKILL.md`-based skills across Claude C
 
 ```bash
 # npm / npx (any platform with Node 20+)
-npm i -g sklt
-npx sklt --help
+npm i -g getskillet
+npx getskillet --help
 
 # macOS / Linux (Homebrew)
 brew install echohello-dev/tap/sklt

--- a/docs/distribution/npm.md
+++ b/docs/distribution/npm.md
@@ -1,14 +1,15 @@
 # npm Distribution
 
-Skillet publishes an npm package so users can run:
+Skillet publishes an npm package named `getskillet` so users can run:
 
-- `npx sklt ...`
-- `bunx sklt ...`
+- `npx getskillet ...`
+- `bunx getskillet ...`
+- `npm i -g getskillet` then `sklt ...`
 
 ## Packaging Model
 
 - `src/cli.ts` is bundled to `dist/npm/cli.js` targeting Node.
-- `package.json` exposes `sklt` pointing to `dist/npm/cli.js`.
+- `package.json` name is `getskillet`; the `bin` field exposes `sklt` pointing to `dist/npm/cli.js`.
 - `prepack` rebuilds the npm CLI bundle automatically.
 
 ## Local Validation
@@ -16,8 +17,8 @@ Skillet publishes an npm package so users can run:
 ```bash
 mise run build-npm
 npm pack
-npx --yes --package ./sklt-<version>.tgz sklt --help
-bunx --bun --package ./sklt-<version>.tgz sklt --help
+npx --yes --package ./getskillet-<version>.tgz sklt --help
+bunx --bun --package ./getskillet-<version>.tgz sklt --help
 mise run npm-publish-dry-run
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide takes you from zero to your first `sklt install` in about five minute
 
 ## 1. Install `sklt`
 
-Pick the install method that matches your platform. The package name is `sklt`.
+Pick the install method that matches your platform. The binary is `sklt` everywhere; the npm package name is `getskillet`.
 
 ### macOS / Linux (recommended)
 
@@ -17,7 +17,7 @@ Or pick a specific channel:
 | Channel | Command | Notes |
 | --- | --- | --- |
 | **Homebrew** | `brew install echohello-dev/tap/sklt` | macOS, Linuxbrew |
-| **npm** | `npm i -g sklt` or use `npx sklt` | Node 20+ |
+| **npm** | `npm i -g getskillet` or use `npx getskillet` | Node 20+ |
 | **Direct binary** | Download from [GitHub Releases](https://github.com/echohello-dev/skillet/releases) | Single static binary, no runtime |
 
 ### Windows
@@ -30,7 +30,7 @@ irm https://echohello.dev/sklt/install.ps1 | iex
 | --- | --- | --- |
 | **winget** | `winget install echohello-dev.sklt` | Windows 10+ |
 | **Chocolatey** | `choco install sklt` | |
-| **npm** | `npm i -g sklt` | Node 20+ |
+| **npm** | `npm i -g getskillet` | Node 20+ |
 
 ### Container
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sklt",
+  "name": "getskillet",
   "version": "1.0.0",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary

Renames the npm package from `sklt` to `getskillet`. The binary name (`sklt`) is unchanged.

## Why

npm rejected `sklt` with `403 Package name too similar to existing packages (st, solc, sift, split)`. `skillet` is already taken. `getskillet` is available, reads naturally as a verb-noun install command, and keeps the brand coherent.

## Changes

- `package.json` — name changed to `getskillet`
- `README.md` — npm install commands use `npm i -g getskillet` and `npx getskillet`
- `docs/getting-started.md` — same
- `docs/distribution/npm.md` — packaging model section updated

## Verification

- `mise run test` — 21 files, 103 tests pass
- `mise run npm-publish-dry-run` — shows `getskillet@1.0.0` publishing successfully

## Next step

Re-trigger `npm-publish.yaml` against `sklt-v1.0.0` to actually publish the renamed package to npm.