### PR TITLE
ci(npm): switch to npm Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: npm-publish-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref }}
@@ -31,10 +32,6 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: npm-publish
-
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     steps:
       - name: Checkout

--- a/docs/distribution/npm.md
+++ b/docs/distribution/npm.md
@@ -34,9 +34,20 @@ npm publish --access public
 - Manual publish is available through `workflow_dispatch`; provide an explicit git ref, usually a release tag like `v1.0.0`.
 - Manual publish also supports a dry run so you can inspect the package contents without uploading to npm.
 - `mise run ci` now includes the npm publish dry run so package publishing is validated in CI before release.
-- The workflow uses the GitHub Actions environment `npm-publish`.
-- Add `NPM_TOKEN` as an environment secret in `npm-publish` using the value from your local `.env`.
-- GitHub Actions cannot read your local `.env` file directly.
+- **Uses npm Trusted Publishers** — no long-lived `NPM_TOKEN` secret required. The workflow uses GitHub OIDC (`id-token: write`) and `actions/setup-node`'s built-in OIDC support; npm verifies the workflow identity against the trusted publisher configured on the package.
+
+### First-time setup (one-time, on npmjs.com)
+
+1. **Create the package on npm** — either by publishing manually once (`npm publish --access public` from your local machine, or use the npm web UI to claim the name), or by triggering the workflow below in dry-run mode and then asking the maintainer to do a one-shot token publish.
+2. **Configure the Trusted Publisher** on https://www.npmjs.com/package/getskillet/access:
+   - **Publisher:** GitHub Actions
+   - **Organization or user:** `echohello-dev`
+   - **Repository:** `skillet`
+   - **Workflow filename:** `npm-publish.yaml`
+   - **Environment name:** *(leave blank)*
+3. **Confirm the workflow file** at `.github/workflows/npm-publish.yaml` has `id-token: write` in its `permissions:` block (already set).
+
+After this, all future `npm-publish` runs authenticate via OIDC — no token to rotate, leak, or steal.
 
 Manual dispatch inputs:
 


### PR DESCRIPTION
## Summary

Replaces the long-lived `NPM_TOKEN` secret with **npm Trusted Publishers** (OIDC). The workflow now authenticates to npm via a short-lived OIDC token that npm verifies against the package's configured trusted publisher. No token to rotate, leak, or steal.

## Changes

- **`npm-publish.yaml`** — add `id-token: write` permission; drop `NPM_TOKEN` env var and the `environment: npm-publish` gating (no longer needed for secret scoping; use environment protection rules for approval gates if desired).
- **`docs/distribution/npm.md`** — one-time setup steps for configuring the trusted publisher on npmjs.com.

## Verification

- `mise run test` — 21 files, 103 tests pass.
- No code or test changes; pure CI/docs.

## Manual steps (one-time, on npmjs.com)

1. **Create `getskillet` on npm** — manual `npm publish --access public` from your local machine (or trigger the workflow in dry-run mode + ask a maintainer to do a one-shot token publish).
2. **Configure the trusted publisher** at https://www.npmjs.com/package/getskillet/access:
   - Publisher: **GitHub Actions**
   - Org/user: `echohello-dev`
   - Repository: `skillet`
   - Workflow filename: `npm-publish.yaml`
   - Environment: *(blank)*
3. **Trigger the workflow** (push a tag or re-run dispatch) — npm will accept the publish because the OIDC token proves the workflow identity.

After that, every release just publishes. No secrets to manage.