### PR TITLE
ci(npm): dual-publish as @echohello/skillet alias

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -77,3 +77,33 @@ jobs:
       - name: Publish package
         if: steps.package.outputs.published != 'true' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
         run: npm publish --access public --tag "${{ github.event_name == 'workflow_dispatch' && inputs.npm_tag || 'latest' }}"
+
+      - name: Publish scoped alias
+        if: steps.package.outputs.published != 'true' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        env:
+          ALIAS_SCOPE: "@echohello"
+        run: |
+          set -euo pipefail
+          VERSION=$(node --print "require('./package.json').version")
+          ALIAS_NAME="${ALIAS_SCOPE}/skillet"
+
+          # Skip if the alias version is already published
+          if npm view "${ALIAS_NAME}@${VERSION}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "${ALIAS_NAME}@${VERSION} is already published; skipping."
+            exit 0
+          fi
+
+          # Build a separate package.json in a clean dir for the scoped publish
+          ALIAS_DIR="dist/npm-alias"
+          rm -rf "$ALIAS_DIR"
+          mkdir -p "$ALIAS_DIR"
+          cp dist/npm/cli.js "$ALIAS_DIR/"
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.name = '${ALIAS_NAME}';
+            fs.writeFileSync('${ALIAS_DIR}/package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          cd "$ALIAS_DIR"
+          npm publish --access public --tag "${{ github.event_name == 'workflow_dispatch' && inputs.npm_tag || 'latest' }}"

--- a/docs/distribution/npm.md
+++ b/docs/distribution/npm.md
@@ -1,15 +1,17 @@
 # npm Distribution
 
-Skillet publishes an npm package named `getskillet` so users can run:
+Skillet publishes the same content under two npm names so users can install with whichever they prefer:
 
-- `npx getskillet ...`
-- `bunx getskillet ...`
-- `npm i -g getskillet` then `sklt ...`
+- **`getskillet`** (primary, unscoped) — `npm i -g getskillet` or `npx getskillet ...`
+- **`@echohello/skillet`** (alias, scoped) — `npm i -g @echohello/skillet` or `npx @echohello/skillet ...`
+
+After install, the binary is the same in both cases: `sklt`.
 
 ## Packaging Model
 
 - `src/cli.ts` is bundled to `dist/npm/cli.js` targeting Node.
-- `package.json` name is `getskillet`; the `bin` field exposes `sklt` pointing to `dist/npm/cli.js`.
+- The primary `package.json` is `getskillet`; the `bin` field exposes `sklt` pointing to `dist/npm/cli.js`.
+- The CI workflow re-builds the same bundle under `dist/npm-alias/` with a rewritten `name: @echohello/skillet` and publishes it as the scoped alias. Same tarball content, different package identity.
 - `prepack` rebuilds the npm CLI bundle automatically.
 
 ## Local Validation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,8 @@ Or pick a specific channel:
 | Channel | Command | Notes |
 | --- | --- | --- |
 | **Homebrew** | `brew install echohello-dev/tap/sklt` | macOS, Linuxbrew |
-| **npm** | `npm i -g getskillet` or use `npx getskillet` | Node 20+ |
+| **npm (unscoped)** | `npm i -g getskillet` or use `npx getskillet` | Node 20+ |
+| **npm (scoped alias)** | `npm i -g @echohello/skillet` | Same package, scoped name |
 | **Direct binary** | Download from [GitHub Releases](https://github.com/echohello-dev/skillet/releases) | Single static binary, no runtime |
 
 ### Windows
@@ -30,7 +31,8 @@ irm https://echohello.dev/sklt/install.ps1 | iex
 | --- | --- | --- |
 | **winget** | `winget install echohello-dev.sklt` | Windows 10+ |
 | **Chocolatey** | `choco install sklt` | |
-| **npm** | `npm i -g getskillet` | Node 20+ |
+| **npm (unscoped)** | `npm i -g getskillet` | Node 20+ |
+| **npm (scoped alias)** | `npm i -g @echohello/skillet` | Same package, scoped name |
 
 ### Container
 


### PR DESCRIPTION
## Summary

The `npm-publish` workflow now publishes the same content under two npm names so users can install with whichever they prefer:

- `**getskillet**` (primary, unscoped) — `npm i -g getskillet`
- `**@echohello/skillet**` (alias, scoped) — `npm i -g @echohello/skillet`

Both expose the same `sklt` binary.

## Changes

- **`npm-publish.yaml`** — new `Publish scoped alias` step that copies the existing `dist/npm/cli.js` into `dist/npm-alias/`, rewrites `package.json` with `name: @echohello/skillet`, and publishes. The step is skipped if the version is already published under that name.
- **`docs/distribution/npm.md`** and **`docs/getting-started.md`** — document both install paths.

## Verification

- `mise run test` — 21 files, 103 tests pass.
- No code or test changes; pure CI/docs.

## One-time npm setup required

Before the first @echohello/skillet publish can succeed via OIDC:

1. **First manual publish** to create the package (Trusted Publisher config can only be set after the package exists):
   ```bash
   # With the legacy token you have, or via the web UI
   npm pkg set name="@echohello/skillet"
   npm publish --access public
   npm pkg set name="getskillet"  # restore primary name
   ```
2. **Configure Trusted Publisher** on https://www.npmjs.com/package/@echohello/skillet/access:
   - Publisher: GitHub Actions
   - Org/user: `echohello-dev`
   - Repository: `skillet`
   - Workflow filename: `npm-publish.yaml`

After that, the workflow handles both names automatically via OIDC.

## Rollout

Once the manual first publish is done and Trusted Publisher is configured, the next release-please PR merge will publish both `getskillet@<version>` and `@echohello/skillet@<version>` in one workflow run.