### PR TITLE
refactor(cli): rename default binary to skillet with sklt alias

### DIFF
--- a/.github/workflows/build-matrix.yaml
+++ b/.github/workflows/build-matrix.yaml
@@ -106,7 +106,7 @@ jobs:
           set -euo pipefail
           OUTPUT=$(docker run --rm --platform linux/arm64/v8 -v "$PWD/dist:/artifacts:ro" alpine:3.22 sh -c 'apk add --no-cache libstdc++ libgcc >/dev/null && /artifacts/skillet-linux-arm64-musl --version')
           printf '%s\n' "$OUTPUT"
-          grep -F "sklt/" <<< "$OUTPUT"
+          grep -F "skillet/" <<< "$OUTPUT"
 
       - name: Smoke test arm64 gnu artifact under emulation
         shell: bash
@@ -114,7 +114,7 @@ jobs:
           set -euo pipefail
           OUTPUT=$(docker run --rm --platform linux/arm64/v8 -v "$PWD/dist:/artifacts:ro" ubuntu:24.04 /artifacts/skillet-linux-arm64-gnu --version)
           printf '%s\n' "$OUTPUT"
-          grep -F "sklt/" <<< "$OUTPUT"
+          grep -F "skillet/" <<< "$OUTPUT"
 
   wine-smoke:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .DS_Store
 dist/
+.env
+.entire/

--- a/.mise.toml
+++ b/.mise.toml
@@ -35,7 +35,7 @@ run = "mise run install && bun scripts/build-npm-cli.ts"
 run = "mise run install && bun scripts/validate-packaging.ts"
 
 [tasks.npm-smoke]
-run = "mise run build-npm && npm pack >/tmp/skillet-npm-pack.log && PACKAGE=$(tail -n 1 /tmp/skillet-npm-pack.log) && npx --yes --package \"./$PACKAGE\" sklt --help && REPO_DIR=\"$PWD\" && TMP_DIR=$(mktemp -d) && (cd \"$TMP_DIR\" && bun init -y >/dev/null 2>&1 && bun add \"$REPO_DIR/$PACKAGE\" >/dev/null && bunx --bun sklt --help) && rm -rf \"$TMP_DIR\" \"$PACKAGE\""
+run = "mise run build-npm && npm pack >/tmp/skillet-npm-pack.log && PACKAGE=$(tail -n 1 /tmp/skillet-npm-pack.log) && npx --yes --package \"./$PACKAGE\" skillet --help && npx --yes --package \"./$PACKAGE\" sklt --help && REPO_DIR=\"$PWD\" && TMP_DIR=$(mktemp -d) && (cd \"$TMP_DIR\" && bun init -y >/dev/null 2>&1 && bun add \"$REPO_DIR/$PACKAGE\" >/dev/null && bunx --bun skillet --help && bunx --bun sklt --help) && rm -rf \"$TMP_DIR\" \"$PACKAGE\""
 
 [tasks.npm-publish-dry-run]
 run = "mise run build-npm && DIST_TAG=${NPM_DIST_TAG:-dry-run} && npm publish --dry-run --access public --tag \"$DIST_TAG\""

--- a/README.md
+++ b/README.md
@@ -1,140 +1,266 @@
-# Skillet
+<div align="center">
 
-Portable CLI for managing agent skills.
+```
+     _    _ _ _      _   
+ ___| | _(_) | | ___| |_ 
+/ __| |/ / | | |/ _ \ __|
+\__ \   <| | | |  __/ |_ 
+|___/_|\_\_|_|_|\___|\__|
+                        
+```
 
-Skillet installs, discovers, and updates `SKILL.md`-based skills across Claude Code, Codex, OpenCode, Cursor, and Windsurf.
+**Portable CLI for managing agent skills. Single static binary, OpenAPM-compatible manifests, OCI-native artifacts.**
 
-## Why Skillet
+[Quick Start](#quick-start) · [Commands](#commands) · [Manifest](#manifest) · [Roadmap](#roadmap) · [Docs](#documentation)
 
-- **Manifest-driven** — declare your skills in `apm.yml` and `sklt install` reproduces the tree on any machine.
-- **OpenAPM-compatible** — `apm.yml` conforms to the [OpenAPM v0.1](https://microsoft.github.io/apm/reference/manifest-schema/) spec, with a focused skills-only profile.
-- **OCI-native** — publish and consume skills as signed `oci://` artifacts. Air-gapped, provenance-friendly, enterprise-ready.
-- **Single static binary** — no Python runtime, no Node dependency for native installs. Drops into CI runners, Docker images, and locked-down endpoints.
-- **Symlink-first** — edit a skill in your repo, see it live in the agent immediately. No reinstall dance.
+|         |                                                                                                                                                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CI/CD   | [![CI](https://github.com/echohello-dev/skillet/actions/workflows/ci.yml/badge.svg)](https://github.com/echohello-dev/skillet/actions) [![Release](https://github.com/echohello-dev/skillet/actions/workflows/release-please.yml/badge.svg)](https://github.com/echohello-dev/skillet/releases) |
+| Package | [![npm](https://img.shields.io/npm/v/getskillet?color=blue)](https://www.npmjs.com/package/getskillet) [![npm (scoped)](https://img.shields.io/npm/v/@echohello/skillet?color=blue)](https://www.npmjs.com/package/@echohello/skillet) [![Docker](https://img.shields.io/badge/ghcr.io-echohello--dev%2Fskillet-blue)](https://ghcr.io/echohello-dev/skillet) |
+| Meta    | [![License: MIT](https://img.shields.io/github/license/echohello-dev/skillet?color=blue)](LICENSE) [![Node 20+](https://img.shields.io/badge/node-20%2B-339933)](https://nodejs.org) [![Bun 1.2](https://img.shields.io/badge/bun-1.2-f9f1e1)](https://bun.sh) |
 
-## Install
+</div>
+
+## What this is
+
+Skillet is a single-binary CLI that installs, discovers, and updates `SKILL.md`-based skills across Claude Code, Codex, OpenCode, Cursor, and Windsurf. It reads the [OpenAPM v0.1](https://microsoft.github.io/apm/reference/manifest-schema/) manifest format, ships skills as signed OCI artifacts, and links them into agent directories with one command.
+
+Every install method produces the same `skillet` binary. `sklt` is a shorthand alias (both names point to the same CLI).
+
+## Quick Start
+
+Install:
 
 ```bash
-# npm / npx (any platform with Node 20+)
+# npm (Node 20+, works everywhere)
 npm i -g getskillet
-npx getskillet --help
 
-# macOS / Linux (Homebrew)
-brew install echohello-dev/tap/sklt
+# macOS / Linux
+brew install echohello-dev/tap/skillet
 
-# Windows (winget)
-winget install echohello-dev.sklt
+# Windows
+winget install echohello-dev.skillet
 
-# Container
+# Container (no install)
 docker run --rm ghcr.io/echohello-dev/skillet --help
-
-# Static binary — download from GitHub Releases
-# https://github.com/echohello-dev/skillet/releases
 ```
 
-All install methods ship the same `sklt` binary. See [docs/getting-started.md](./docs/getting-started.md) for the full install matrix and per-platform notes.
-
-## Quick start
+Run it:
 
 ```bash
-# Scaffold an apm.yml in your project
-mkdir my-agent-skills && cd my-agent-skills
-sklt init
+$ skillet --help
+skillet/1.1.0
 
-# Add a skill from any supported source
-sklt add anthropics/skills
+Usage:
+  $ skillet <command> [options]
 
-# Or declare everything up front and install in one shot
-echo 'dependencies:
-  apm:
-    - anthropics/skills/skills/frontend-design
-    - oci://ghcr.io/your-org/team-skills:v1' >> apm.yml
-sklt install
+Commands:
+  add [...args]            Install skills from a source
+  find [...args]           Search available skills
+  check [...args]          Check for updates to installed skills
+  update [...args]         Update installed skills
+  init [...args]           Create a SKILL.md template
+  install [...args]        Install dependencies from apm.yml
+  generate-lock [...args]  Generate skillet.lock.yaml
 
-# Verify what's on disk
-sklt find
+Options:
+  -y, --yes      Skip confirmations
+  --verbose      Enable verbose output
+  -v, --version  Display version number
+  -h, --help     Display this message
 ```
 
-See [docs/usage.md](./docs/usage.md) for the full command reference, manifest schema, and source format guide.
+Scaffold a project, add a skill, install everything in the manifest:
+
+```bash
+$ mkdir my-agent-skills && cd my-agent-skills
+$ skillet init
+Created ./SKILL.md
+
+$ skillet add anthropics/skills --skill frontend-design
+Resolved anthropics/skills@4a7c1b6 (HEAD)
+Linked frontend-design → .claude/skills/frontend-design
+
+$ skillet find
+name                description                                              path
+frontend-design     Creates distinctive, production-grade frontend ...        .claude/skills/frontend-design
+```
+
+The CLI works the same whether invoked as `skillet` or `sklt`. See [docs/getting-started.md](./docs/getting-started.md) for the full install matrix.
+
+## Features
+
+|                 | Skill discovery | `apm.yml` install | OCI artifacts | Lockfile | Static binary | Multi-agent |
+| --------------- | --------------- | ----------------- | ------------- | -------- | ------------- | ----------- |
+| **Skills.sh**   | yes             | no                | no            | no       | no            | no          |
+| **APM CLI**     | partial         | yes               | no            | partial  | no            | yes         |
+| **Vercel CLI**  | no              | no                | no            | no       | partial       | yes         |
+| **Skillet**     | yes             | yes               | yes           | yes      | yes           | yes         |
+
+| Built on                | Purpose                                                              |
+| ----------------------- | -------------------------------------------------------------------- |
+| Bun runtime             | Source execution and bundling                                       |
+| TypeScript              | Implementation language                                             |
+| cac                     | CLI argument parsing                                                 |
+| OpenAPM v0.1 schema     | `apm.yml` manifest format (skills-only profile)                      |
+| OCI distribution spec   | `oci://` skill artifact publishing                                   |
+| release-please          | Versioning, changelog, GitHub releases                               |
 
 ## Commands
 
-| Command | Description |
-| --- | --- |
-| `sklt find [query]` | Search discovered local skills |
-| `sklt init [dir]` | Scaffold a `SKILL.md` |
-| `sklt add <source>` | Install skills from a source |
-| `sklt install` | Install every dependency in `apm.yml` |
-| `sklt check` | *(in progress)* Detect upstream changes |
-| `sklt update` | *(in progress)* Refresh refs and reinstall |
-| `sklt generate-lock` | Regenerate `skillet.lock.yaml` from disk |
+| Command                       | Description                                                |
+| ----------------------------- | ---------------------------------------------------------- |
+| `skillet init [dir]`          | Scaffold a new `SKILL.md` with required frontmatter        |
+| `skillet add <source>`        | Install skills from a source into the agent directory     |
+| `skillet install`             | Install every dependency declared in `apm.yml`             |
+| `skillet find [query]`        | Search discovered local skills                             |
+| `skillet check`               | Detect upstream changes (in progress)                      |
+| `skillet update`              | Refresh refs and reinstall (in progress)                   |
+| `skillet generate-lock`       | Regenerate `skillet.lock.yaml` from disk                   |
 
-Run `sklt --help` for the full list.
+All commands also work with the `sklt` shorthand alias (`sklt find`, `sklt init`, etc.).
+
+## Manifest
+
+`apm.yml` is the source of truth for `skillet install`. Skillet is a scoped conforming resolver for [OpenAPM v0.1](https://microsoft.github.io/apm/reference/manifest-schema/), with a skills-only profile.
+
+```yaml
+name: my-agent-skills
+version: 1.0.0
+target: [claude, codex, opencode, cursor]
+dependencies:
+  apm:
+    - anthropics/skills/skills/frontend-design
+    - github: git@gitlab.internal.acme.com/platform/coding-standards.git
+      ref: v2.0
+      path: skills/security
+    - oci://ghcr.io/acme/security-checklist:v1.2.0
+    - ./team-internal
+```
+
+Honored fields: `name`, `version`, `description`, `target` / `targets`, `dependencies.apm`. Unknown keys (including `dependencies.mcp`, `dependencies.lsp`, `hooks`, `plugins`, `marketplace`) are ignored per the OpenAPM spec. See [docs/adr/0001-apm-manifest-compliance.md](./docs/adr/0001-apm-manifest-compliance.md) for the rationale.
 
 ## Source formats
 
-Skillet resolves any of these as a `sklt add` or `apm.yml` source:
+| Pattern                              | Resolved as                                                |
+| ------------------------------------ | ---------------------------------------------------------- |
+| `owner/repo`                         | GitHub shorthand, HEAD ref                                 |
+| `owner/repo#v1.0.0`                  | GitHub shorthand, pinned ref (branch, tag, or SHA)         |
+| `https://...` or `git@...`           | Full git URL                                               |
+| `oci://registry/repo:tag`            | OCI artifact by tag (resolved to digest in lockfile)       |
+| `oci://registry/repo@sha256:...`     | OCI artifact by digest                                     |
+| `https://.../file.{zip,tar.gz,tgz}`  | HTTP archive (size and path-traversal validated)           |
+| `./path`, `../path`, `~/path`        | Local directory                                            |
 
-- **Git** — `owner/repo`, `owner/repo#v1.0.0`, full `https://` or `git@` URLs
-- **OCI** — `oci://registry/repository:tag` or `oci://registry/repository@sha256:<digest>`
-- **HTTP archive** — `.zip`, `.tar.gz`, `.tgz` (with traversal and size safety checks)
-- **Local** — `./path`, `../path`, `/abs/path`
-
-See [docs/usage.md#source-formats](./docs/usage.md#source-formats) for details.
+HTTP archives are rejected if they exceed size limits or contain path traversal entries. OCI artifacts must use artifact type `application/vnd.skillet.skill.v1+tar`.
 
 ## Supported agents
 
-| Agent | Project scope | Global scope |
-| --- | --- | --- |
-| Claude Code | `.claude/skills` | `~/.claude/skills` |
-| Codex | `.codex/skills` | `~/.codex/skills` |
-| OpenCode | `.opencode/skills` | `~/.opencode/skills` |
-| Cursor | `.cursor/skills` | `~/.cursor/skills` |
-| Windsurf | `.windsurf/skills` | `~/.windsurf/skills` |
+| Agent         | Project scope        | Global scope           |
+| ------------- | -------------------- | ---------------------- |
+| Claude Code   | `.claude/skills`     | `~/.claude/skills`     |
+| Codex         | `.codex/skills`      | `~/.codex/skills`      |
+| OpenCode      | `.opencode/skills`   | `~/.opencode/skills`   |
+| Cursor        | `.cursor/skills`     | `~/.cursor/skills`     |
+| Windsurf      | `.windsurf/skills`   | `~/.windsurf/skills`   |
 
-APM `target:` and `targets:` values map to these names. Unknown targets (e.g. `gemini`, `kiro`, `copilot`) are silently ignored — Skillet is skills-only.
+APM `target:` and `targets:` values map to these names. Unknown targets are silently ignored.
 
-## OCI artifact spec
+## Architecture
 
-`oci://` artifacts must use:
-
-- **Artifact type:** `application/vnd.skillet.skill.v1+tar`
-- **At least one tar layer** containing a single skill directory with `SKILL.md`
-- **Safe extraction** — no path traversal
-
-Tag-based refs are resolved to a manifest digest and recorded in `skillet.lock.yaml` for reproducibility.
-
-Publishing example (conceptual):
-
-```bash
-tar -cf skill.tar <skill-dir>
-oras push ghcr.io/<org>/<skill>:v1 \
-  --artifact-type application/vnd.skillet.skill.v1+tar \
-  skill.tar:application/vnd.oci.image.layer.v1.tar
 ```
+                apm.yml
+                  |
+                  v
+        +-------------------+
+        |   skillet CLI     |
+        |  (single binary)  |
+        +-------------------+
+                  |
+   +--------------+--------------+--------------+
+   |              |              |              |
+   v              v              v              v
++---------+ +-----------+ +-------------+ +-----------+
+|  git    | |   OCI     | |   HTTP      | |  local    |
+| resolver| | resolver  | |  archive    | |  dir      |
++---------+ +-----------+ +-------------+ +-----------+
+                  |
+                  v
+       +---------------------+
+       |  per-agent skill    |
+       |  directories        |
+       |  (.claude, .codex,  |
+       |   .opencode, ...)   |
+       +---------------------+
+                  |
+                  v
+       skillet.lock.yaml  (deterministic, sorted)
+```
+
+Skillet ships as one static binary per target (Linux x64/arm64 musl, macOS x64/arm64, Windows x64). No Python, no Node runtime for native installs. Symlinks point each skill into the agent directory; edits to a skill in your repo appear immediately in the agent without reinstall.
+
+## Philosophy
+
+1. **Manifest-driven.** Reproducible installs are the baseline. `apm.yml` is the contract.
+2. **Standards over invention.** Conform to OpenAPM where it works. Ignore what doesn't apply.
+3. **OCI-native artifacts.** Signed, addressable, air-gappable. No custom registry protocol.
+4. **Symlink-first.** Source of truth is your repo, not the agent directory. Edit and reload.
+5. **Single binary.** Drop into CI runners, locked-down endpoints, scratch containers.
+6. **Skills only.** MCP servers, plugins, hooks, and LSP configs are out of scope. Skillet does one thing.
+
+## Roadmap
+
+| Bucket   | Item                                                               |
+| -------- | ------------------------------------------------------------------ |
+| Shipped  | `init`, `add`, `install`, `find`, `generate-lock`                  |
+| Shipped  | OpenAPM v0.1 manifest support (skills-only profile)                |
+| Shipped  | OCI artifact publishing with artifact-type `vnd.skillet.skill.v1`  |
+| Shipped  | Multi-agent targets (Claude, Codex, OpenCode, Cursor, Windsurf)     |
+| Shipped  | `getskillet` and `@echohello/skillet` npm distribution             |
+| Shipped  | Homebrew / winget / Chocolatey / Docker / static binary distribution |
+| Shipped  | npm Trusted Publishers (OIDC, no long-lived token)                 |
+| Next     | `check` and `update` with ref-change detection                    |
+| Next     | `--frozen` CI mode for `install`                                  |
+| Next     | Signed commits and supply-chain attestations                       |
+| Long-term | Lockfile spec compatibility with `apm.lock.yaml` (ADR-0002)       |
+| Long-term | Multi-agent lockfile groups with per-agent source sets             |
+
+## Documentation
+
+| Topic                          | Doc                                                                   |
+| ------------------------------ | --------------------------------------------------------------------- |
+| Install and first project      | [docs/getting-started.md](./docs/getting-started.md)                  |
+| Command reference              | [docs/usage.md](./docs/usage.md)                                     |
+| OpenAPM conformance rationale  | [docs/adr/0001-apm-manifest-compliance.md](./docs/adr/0001-apm-manifest-compliance.md) |
+| Vercel CLI parity notes        | [docs/parity/2026-02-20-vercel-cli-parity.md](./docs/parity/2026-02-20-vercel-cli-parity.md) |
+
+| Distribution channel           | Doc                                              |
+| ------------------------------ | ------------------------------------------------ |
+| npm                            | [docs/distribution/npm.md](./docs/distribution/npm.md) |
+| Homebrew                       | [docs/distribution/homebrew.md](./docs/distribution/homebrew.md) |
+| Chocolatey                     | [docs/distribution/chocolatey.md](./docs/distribution/chocolatey.md) |
+| winget                         | [docs/distribution/winget.md](./docs/distribution/winget.md) |
+| Docker                         | [docs/distribution/docker.md](./docs/distribution/docker.md) |
 
 ## Development
 
 ```bash
 mise run install     # install dependencies
-mise run test        # run vitest
+mise run test        # run vitest (21 files, 103 tests)
 mise run ci          # test + npm publish dry-run
 mise run dev -- --help
 ```
 
 Project conventions live in `AGENTS.md`. Architecture decisions are in `docs/adr/`.
 
-## Documentation
+## Project status
 
-- [Getting Started](./docs/getting-started.md) — install and first project
-- [Usage](./docs/usage.md) — command reference, manifest schema, source formats
-- [Parity: Vercel CLI](./docs/parity/2026-02-20-vercel-cli-parity.md)
-- [ADR-0001: APM Manifest Compliance](./docs/adr/0001-apm-manifest-compliance.md)
+Stable. The `init`, `add`, `install`, `find`, and `generate-lock` commands are production-ready and the public API is stable. `check` and `update` are implemented behind feature flags and will land in the next minor release.
 
-Distribution channels:
+## License
 
-- [Homebrew](./docs/distribution/homebrew.md)
-- [Chocolatey](./docs/distribution/chocolatey.md)
-- [winget](./docs/distribution/winget.md)
-- [Docker](./docs/distribution/docker.md)
-- [npm](./docs/distribution/npm.md)
+MIT. See [LICENSE](LICENSE).
+
+Built with Bun and TypeScript. CI runs on GitHub Actions. Published to npm, Homebrew, Chocolatey, winget, and ghcr.io.
+
+[![Star History](https://api.star-history.com/svg?repos=echohello-dev/skillet&type=Date)](https://star-history.com/#echohello-dev/skillet&Date)

--- a/docs/adr/0001-apm-manifest-compliance.md
+++ b/docs/adr/0001-apm-manifest-compliance.md
@@ -12,7 +12,7 @@ status: accepted
 
 Microsoft APM (Agent Package Manager) has published the OpenAPM v0.1 specification with a formal JSON Schema for `apm.yml`. The spec explicitly invites third-party conforming resolvers. APM is gaining traction as the de facto dependency manager for agent skills, prompts, and MCP servers across Claude, Copilot, Cursor, OpenCode, Codex, Gemini, and Windsurf.
 
-Skillet (`sklt`) was built as a lightweight, skills-only resolver with unique support for OCI artifacts and single-binary distribution. Until now it had no manifest format — installations were purely CLI-driven (`sklt add <source>`). This creates friction for teams who want reproducible, version-pinned skill trees checked into source control.
+Skillet was built as a lightweight, skills-only resolver with unique support for OCI artifacts and single-binary distribution. Until now it had no manifest format — installations were purely CLI-driven (`skillet add <source>`). This creates friction for teams who want reproducible, version-pinned skill trees checked into source control.
 
 We evaluated three paths:
 1. **Invent `skillet.yml`** — own format, own ecosystem, full control.
@@ -25,10 +25,10 @@ Adopt **Path 2: APM-conforming resolver with a scoped profile**.
 
 - Skillet reads and writes `apm.yml` as its primary manifest.
 - Skillet resolves `dependencies.apm` entries (git, local, HTTP sources) and deploys skills into per-agent directories.
-- Skillet **ignores** `mcp`, `lsp`, `hooks`, `commands`, `plugins`, `marketplace`, `compilation`, and `policy` blocks, surfacing a clear "not supported by sklt" notice when these are present. This aligns with the spec which permits resolvers to ignore unknown keys.
+- Skillet **ignores** `mcp`, `lsp`, `hooks`, `commands`, `plugins`, `marketplace`, `compilation`, and `policy` blocks, surfacing a clear "not supported by skillet" notice when these are present. This aligns with the spec which permits resolvers to ignore unknown keys.
 - Skillet **retains** `skillet.lock.yaml` as its lockfile format for now, with field names aligned to APM's lockfile spec where practical. A future ADR may adopt `apm.lock.yaml` directly.
-- Skillet **adds** `sklt install` as the bare-install command (no arguments = install everything declared in `apm.yml`).
-- `sklt add <source>` updates `apm.yml` when one exists, appending the source to `dependencies.apm`.
+- Skillet **adds** `skillet install` as the bare-install command (no arguments = install everything declared in `apm.yml`).
+- `skillet add <source>` updates `apm.yml` when one exists, appending the source to `dependencies.apm`.
 
 ### Rationale
 
@@ -42,7 +42,7 @@ Adopt **Path 2: APM-conforming resolver with a scoped profile**.
 ### Positive
 - Instant compatibility with APM-authored packages and marketplaces.
 - Teams can migrate between APM and Skillet without rewriting manifests.
-- `sklt install` provides reproducible, manifest-driven workflows.
+- `skillet install` provides reproducible, manifest-driven workflows.
 - Positions Skillet as "the lightweight, OCI-native APM resolver for skills-only workflows."
 
 ### Negative / trade-offs
@@ -53,8 +53,8 @@ Adopt **Path 2: APM-conforming resolver with a scoped profile**.
 ### Follow-ups
 - ADR-0002: Evaluate adopting `apm.lock.yaml` directly vs keeping `skillet.lock.yaml`.
 - Issue: Add virtual-package shorthand support to `src/resolvers/git.ts`.
-- Issue: Implement `--frozen` CI mode for `sklt install`.
-- Issue: Implement `--update` consent-gated ref refresh for `sklt install`.
+- Issue: Implement `--frozen` CI mode for `skillet install`.
+- Issue: Implement `--update` consent-gated ref refresh for `skillet install`.
 
 ## References
 - https://microsoft.github.io/apm/reference/manifest-schema/

--- a/docs/distribution/npm.md
+++ b/docs/distribution/npm.md
@@ -5,12 +5,13 @@ Skillet publishes the same content under two npm names so users can install with
 - **`getskillet`** (primary, unscoped) — `npm i -g getskillet` or `npx getskillet ...`
 - **`@echohello/skillet`** (alias, scoped) — `npm i -g @echohello/skillet` or `npx @echohello/skillet ...`
 
-After install, the binary is the same in both cases: `sklt`.
+After install, the binary is the same in both cases: `skillet` (default) with `sklt` as a shorthand alias — both names are wired in `package.json` `bin` and point at `dist/npm/cli.js`.
 
 ## Packaging Model
 
 - `src/cli.ts` is bundled to `dist/npm/cli.js` targeting Node.
-- The primary `package.json` is `getskillet`; the `bin` field exposes `sklt` pointing to `dist/npm/cli.js`.
+- The primary `package.json` is `getskillet`; the `bin` field exposes both `skillet` and `sklt`, both pointing to `dist/npm/cli.js`.
+- The CLI runtime detects which name the user invoked (via `process.argv[1]`) and rewrites the displayed `bin` so `skillet --version` reports `skillet/1.x.y` while `sklt --version` reports `sklt/1.x.y`. The version number is always identical.
 - The CI workflow re-builds the same bundle under `dist/npm-alias/` with a rewritten `name: @echohello/skillet` and publishes it as the scoped alias. Same tarball content, different package identity.
 - `prepack` rebuilds the npm CLI bundle automatically.
 
@@ -19,9 +20,17 @@ After install, the binary is the same in both cases: `sklt`.
 ```bash
 mise run build-npm
 npm pack
+npx --yes --package ./getskillet-<version>.tgz skillet --help
 npx --yes --package ./getskillet-<version>.tgz sklt --help
+bunx --bun --package ./getskillet-<version>.tgz skillet --help
 bunx --bun --package ./getskillet-<version>.tgz sklt --help
 mise run npm-publish-dry-run
+```
+
+Or run the smoke check that exercises both bin entries end-to-end:
+
+```bash
+mise run npm-smoke
 ```
 
 ## Publish
@@ -46,8 +55,9 @@ npm publish --access public
    - **Organization or user:** `echohello-dev`
    - **Repository:** `skillet`
    - **Workflow filename:** `npm-publish.yaml`
-   - **Environment name:** *(leave blank)*
-3. **Confirm the workflow file** at `.github/workflows/npm-publish.yaml` has `id-token: write` in its `permissions:` block (already set).
+   - **Environment name:** `production` *(must match the `environment:` declared on the publish job)*
+3. **Confirm the workflow file** at `.github/workflows/npm-publish.yaml` has `id-token: write` in its `permissions:` block and a `production` GitHub Environment exists (already set).
+4. Repeat step 2 for the alias package at https://www.npmjs.com/package/@echohello/skillet/access if you also want OIDC publishes for the scoped name.
 
 After this, all future `npm-publish` runs authenticate via OIDC — no token to rotate, leak, or steal.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,22 +1,24 @@
 # Getting Started
 
-This guide takes you from zero to your first `sklt install` in about five minutes.
+This guide takes you from zero to your first `skillet install` in about five minutes.
 
-## 1. Install `sklt`
+**Binary naming:** the default command is `skillet`. `sklt` is provided as a shorthand alias — both names point to the same binary and accept the same arguments. All examples below use `skillet`; substitute `sklt` if you prefer the short form.
 
-Pick the install method that matches your platform. The binary is `sklt` everywhere; the npm package name is `getskillet`.
+## 1. Install Skillet
+
+Pick the install method that matches your platform. The npm package is `getskillet` (unscoped) with `@echohello/skillet` as a scoped alias; the binary is `skillet` (default) with `sklt` as an alias.
 
 ### macOS / Linux (recommended)
 
 ```bash
-curl -sSL https://echohello.dev/sklt/install.sh | sh
+curl -sSL https://echohello.dev/skillet/install.sh | sh
 ```
 
 Or pick a specific channel:
 
 | Channel | Command | Notes |
 | --- | --- | --- |
-| **Homebrew** | `brew install echohello-dev/tap/sklt` | macOS, Linuxbrew |
+| **Homebrew** | `brew install echohello-dev/tap/skillet` | macOS, Linuxbrew |
 | **npm (unscoped)** | `npm i -g getskillet` or use `npx getskillet` | Node 20+ |
 | **npm (scoped alias)** | `npm i -g @echohello/skillet` | Same package, scoped name |
 | **Direct binary** | Download from [GitHub Releases](https://github.com/echohello-dev/skillet/releases) | Single static binary, no runtime |
@@ -24,13 +26,13 @@ Or pick a specific channel:
 ### Windows
 
 ```powershell
-irm https://echohello.dev/sklt/install.ps1 | iex
+irm https://echohello.dev/skillet/install.ps1 | iex
 ```
 
 | Channel | Command | Notes |
 | --- | --- | --- |
-| **winget** | `winget install echohello-dev.sklt` | Windows 10+ |
-| **Chocolatey** | `choco install sklt` | |
+| **winget** | `winget install echohello-dev.skillet` | Windows 10+ |
+| **Chocolatey** | `choco install skillet` | |
 | **npm (unscoped)** | `npm i -g getskillet` | Node 20+ |
 | **npm (scoped alias)** | `npm i -g @echohello/skillet` | Same package, scoped name |
 
@@ -43,8 +45,15 @@ docker run --rm ghcr.io/echohello-dev/skillet --help
 ### Verify
 
 ```bash
+skillet --version
+# skillet/1.0.0 (commit=..., builtAt=..., target=...)
+```
+
+After global install, the `sklt` shorthand also works:
+
+```bash
 sklt --version
-# sklt/1.0.0 (commit=..., builtAt=..., target=...)
+# skillet/1.0.0 (commit=..., builtAt=..., target=...)
 ```
 
 ## 2. Start a project
@@ -53,7 +62,7 @@ Create a new project directory and scaffold a manifest:
 
 ```bash
 mkdir my-agent-skills && cd my-agent-skills
-sklt init
+skillet init
 ```
 
 This writes an `apm.yml` manifest declaring your project. Open it — it looks like this:
@@ -74,19 +83,19 @@ Point Skillet at any source that contains `SKILL.md` files:
 
 ```bash
 # GitHub repo (uses git shorthand: owner/repo)
-sklt add anthropics/skills
+skillet add anthropics/skills
 
 # Specific branch or tag
-sklt add anthropics/skills#main
+skillet add anthropics/skills#main
 
 # OCI artifact from a registry
-sklt add oci://ghcr.io/echohello-dev/frontend-design:v1
+skillet add oci://ghcr.io/echohello-dev/frontend-design:v1
 
 # Local directory
-sklt add ../my-local-skills
+skillet add ../my-local-skills
 ```
 
-`sklt add` resolves the source, discovers the skills inside it, and deploys them into your agent directory. By default it writes to whichever agent directory it finds (`.claude/skills`, `.codex/skills`, etc.). If none is found, it prompts you.
+`skillet add` resolves the source, discovers the skills inside it, and deploys them into your agent directory. By default it writes to whichever agent directory it finds (`.claude/skills`, `.codex/skills`, etc.). If none is found, it prompts you.
 
 The source is appended to `apm.yml` so your install is reproducible.
 
@@ -95,7 +104,7 @@ The source is appended to `apm.yml` so your install is reproducible.
 For reproducible installs across machines, commit an `apm.yml` and run:
 
 ```bash
-sklt install
+skillet install
 ```
 
 This reads every entry under `dependencies.apm` and installs it. No arguments required — `apm.yml` is the source of truth.
@@ -122,13 +131,13 @@ See [Usage](./usage.md#manifest-format) for the full schema and source formats.
 List the skills Skillet discovered in your project:
 
 ```bash
-sklt find
+skillet find
 ```
 
 Or search by keyword:
 
 ```bash
-sklt find deploy
+skillet find deploy
 ```
 
 Inspect the lockfile (`skillet.lock.yaml`) to see what's installed, where it came from, and how it was placed:
@@ -139,21 +148,21 @@ cat skillet.lock.yaml
 
 ## 6. Update
 
-When you want to refresh sources, edit the refs in `apm.yml` and re-run `sklt install`. For automated detection of newer refs:
+When you want to refresh sources, edit the refs in `apm.yml` and re-run `skillet install`. For automated detection of newer refs:
 
 ```bash
-sklt check    # show what would change
-sklt update   # refresh refs and reinstall
+skillet check    # show what would change
+skillet update   # refresh refs and reinstall
 ```
 
-(`check` and `update` are in-progress; today, bump refs in `apm.yml` manually and re-run `sklt install`.)
+(`check` and `update` are in-progress; today, bump refs in `apm.yml` manually and re-run `skillet install`.)
 
 ## 7. Iterate
 
 Author a new skill in your project:
 
 ```bash
-sklt init skills/team-voice
+skillet init skills/team-voice
 ```
 
 This scaffolds `skills/team-voice/SKILL.md` with the required frontmatter (`name`, `description`). Edit the body to define when the skill should trigger and what the agent should do.

--- a/docs/parity/2026-02-20-vercel-cli-parity.md
+++ b/docs/parity/2026-02-20-vercel-cli-parity.md
@@ -45,7 +45,7 @@ Compared against: [OpenAPM v0.1 manifest schema](https://microsoft.github.io/apm
 | `policy` | Consumer-side org policy | Not supported | Intentional gap | Out of scope. |
 | `compilation` | `apm compile` settings | Not supported | Intentional gap | Out of scope. |
 | `marketplace` | Marketplace authoring block | Not supported | Intentional gap | Out of scope. |
-| `sklt install` | `apm install` equivalent | Implemented | Partial | No `--frozen`, `--update`, or transitive resolution yet. |
+| `skillet install` | `apm install` equivalent | Implemented | Partial | No `--frozen`, `--update`, or transitive resolution yet. |
 | Lockfile | `apm.lock.yaml` | `skillet.lock.yaml` | Partial | Field names aligned where practical; may adopt `apm.lock.yaml` in future ADR. |
 
 ## Decisions

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,33 +1,35 @@
 # Usage
 
-Full reference for `sklt` commands, the `apm.yml` manifest, and supported source formats.
+Full reference for `skillet` commands, the `apm.yml` manifest, and supported source formats.
+
+**Binary naming:** every command below works with `skillet` (default) or `sklt` (shorthand alias). Both names point to the same binary.
 
 ## Commands
 
 ```bash
-sklt --help            # show all commands
-sklt --version         # print version + build metadata
+skillet --help            # show all commands
+skillet --version         # print version + build metadata
 ```
 
-### `sklt find [query]`
+### `skillet find [query]`
 
 Search skills already discovered on the current machine.
 
 ```bash
-sklt find                # list all discovered skills
-sklt find deploy         # filter by name or description keyword
+skillet find                # list all discovered skills
+skillet find deploy         # filter by name or description keyword
 ```
 
 Discovers skills from project directories (`.claude/skills`, `.codex/skills`, `.opencode/skills`, `.cursor/skills`, `.windsurf/skills`) and global equivalents in `$HOME`. Invalid `SKILL.md` files are skipped.
 
-### `sklt init [directory]`
+### `skillet init [directory]`
 
 Scaffold a new `SKILL.md` with the required frontmatter.
 
 ```bash
-sklt init                       # scaffold ./SKILL.md
-sklt init skills/team-voice     # scaffold skills/team-voice/SKILL.md
-sklt init skills/team-voice -y  # overwrite if it exists
+skillet init                       # scaffold ./SKILL.md
+skillet init skills/team-voice     # scaffold skills/team-voice/SKILL.md
+skillet init skills/team-voice -y  # overwrite if it exists
 ```
 
 The scaffolded file contains:
@@ -45,17 +47,17 @@ Describe what this skill does and when to use it.
 
 The directory name must be lowercase alphanumeric with optional hyphens (1–64 chars).
 
-### `sklt add <source>`
+### `skillet add <source>`
 
 Install skills from a single source.
 
 ```bash
-sklt add owner/repo                          # GitHub shorthand
-sklt add owner/repo#v1.2.0                   # pinned to a git ref
-sklt add https://github.com/owner/repo.git   # full git URL
-sklt add oci://ghcr.io/org/skill:v1          # OCI artifact
-sklt add https://example.com/skills.zip     # HTTP archive
-sklt add ./local-skills                      # local directory
+skillet add owner/repo                          # GitHub shorthand
+skillet add owner/repo#v1.2.0                   # pinned to a git ref
+skillet add https://github.com/owner/repo.git   # full git URL
+skillet add oci://ghcr.io/org/skill:v1          # OCI artifact
+skillet add https://example.com/skills.zip     # HTTP archive
+skillet add ./local-skills                      # local directory
 ```
 
 Flags:
@@ -74,26 +76,26 @@ Examples:
 
 ```bash
 # Preview what's available before installing
-sklt add owner/repo --list
+skillet add owner/repo --list
 
 # Install a single skill from a multi-skill repo
-sklt add owner/repo --skill frontend-design
+skillet add owner/repo --skill frontend-design
 
 # Install all skills to a specific agent
-sklt add owner/repo --all --agent codex
+skillet add owner/repo --all --agent codex
 
 # Copy instead of symlink (useful for system-managed agent dirs)
-sklt add owner/repo --all --copy
+skillet add owner/repo --all --copy
 ```
 
-If `apm.yml` exists in the current directory, `sklt add` appends the source to `dependencies.apm` (no duplicates).
+If `apm.yml` exists in the current directory, `skillet add` appends the source to `dependencies.apm` (no duplicates).
 
-### `sklt install`
+### `skillet install`
 
 Install every dependency declared in `apm.yml`. No arguments required.
 
 ```bash
-sklt install
+skillet install
 ```
 
 Resolves each `dependencies.apm` entry in declaration order and deploys the discovered skills to the target agent directory.
@@ -104,7 +106,7 @@ Target selection:
 - Use `--agent` to override:
 
 ```bash
-sklt install --agent claude,cursor
+skillet install --agent claude,cursor
 ```
 
 Other flags:
@@ -113,21 +115,21 @@ Other flags:
 | --- | --- |
 | `--dry-run` | Print the install plan without writing anything |
 
-### `sklt check` (in progress)
+### `skillet check` (in progress)
 
 Show which installed skills have newer refs available upstream.
 
-### `sklt update` (in progress)
+### `skillet update` (in progress)
 
 Refresh refs to the latest matching versions and reinstall.
 
-### `sklt generate-lock`
+### `skillet generate-lock`
 
 Re-generate `skillet.lock.yaml` from the skills currently on disk. Useful if the lockfile gets out of sync with reality (e.g., manual edits).
 
 ## Manifest format (`apm.yml`)
 
-`apm.yml` is the source of truth for `sklt install`. Skillet is a scoped conforming resolver for [OpenAPM v0.1](https://microsoft.github.io/apm/reference/manifest-schema/).
+`apm.yml` is the source of truth for `skillet install`. Skillet is a scoped conforming resolver for [OpenAPM v0.1](https://microsoft.github.io/apm/reference/manifest-schema/).
 
 ### Schema (supported subset)
 
@@ -191,10 +193,10 @@ Unknown top-level keys are ignored per the OpenAPM spec.
 ### Git
 
 ```bash
-sklt add owner/repo
-sklt add owner/repo#v2.0
-sklt add git@github.com:owner/repo.git
-sklt add https://gitlab.com/group/sub/repo.git
+skillet add owner/repo
+skillet add owner/repo#v2.0
+skillet add git@github.com:owner/repo.git
+skillet add https://gitlab.com/group/sub/repo.git
 ```
 
 Clones to a temporary directory, checks out the ref, then symlinks skills into the target agent dir. Records the commit SHA in the lockfile for reproducibility.
@@ -202,8 +204,8 @@ Clones to a temporary directory, checks out the ref, then symlinks skills into t
 ### OCI
 
 ```bash
-sklt add oci://ghcr.io/org/skill:v1
-sklt add oci://ghcr.io/org/skill@sha256:abc123...
+skillet add oci://ghcr.io/org/skill:v1
+skillet add oci://ghcr.io/org/skill@sha256:abc123...
 ```
 
 Published artifacts must use artifact type `application/vnd.skillet.skill.v1+tar` and contain a single tar layer. See the [OCI Artifact Spec](../README.md#oci-artifact-spec).
@@ -211,8 +213,8 @@ Published artifacts must use artifact type `application/vnd.skillet.skill.v1+tar
 ### HTTP archives
 
 ```bash
-sklt add https://example.com/skills.zip
-sklt add https://example.com/skills.tar.gz
+skillet add https://example.com/skills.zip
+skillet add https://example.com/skills.tar.gz
 ```
 
 Skillet validates that the archive is within size limits and contains no path traversal entries.
@@ -220,8 +222,8 @@ Skillet validates that the archive is within size limits and contains no path tr
 ### Local directories
 
 ```bash
-sklt add ./my-skills
-sklt add /abs/path/to/skills
+skillet add ./my-skills
+skillet add /abs/path/to/skills
 ```
 
 Searches the directory for `SKILL.md` files in standard locations (`./skills/`, subdirectories, or a recursive fallback).
@@ -263,7 +265,7 @@ Use `--global` / `-g` to install to the user-scope directory.
 **Dev loop:** use a local source and symlink installs.
 
 ```bash
-sklt add ./my-skill --skill my-skill -y
+skillet add ./my-skill --skill my-skill -y
 # Edit ./my-skill/SKILL.md; the symlinked copy in .claude/skills/ updates immediately
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "README.md"
   ],
   "bin": {
+    "skillet": "dist/npm/cli.js",
     "sklt": "dist/npm/cli.js"
   },
   "scripts": {

--- a/scripts/smoke-artifact.ts
+++ b/scripts/smoke-artifact.ts
@@ -33,7 +33,7 @@ function main(): void {
     stdio: ["ignore", "pipe", "pipe"],
   });
 
-  if (!output.includes("sklt/")) {
+  if (!output.includes("skillet/")) {
     throw new Error(`Unexpected smoke output: ${output}`);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ const COMMAND_HELP: Record<CommandName, string> = {
   "generate-lock": "Generate skillet.lock.yaml",
 };
 
-const cli = cac("sklt");
+const cli = cac("skillet");
 const GLOBAL_FLAGS = new Set(["-y", "--yes", "--verbose", "-v", "--version", "-h", "--help"]);
 
 cli
@@ -131,6 +131,18 @@ function findUnknownGlobalFlag(argv: string[]): string | undefined {
 
 const rawArgs = process.argv.slice(2);
 const unknownGlobalFlag = findUnknownGlobalFlag(rawArgs);
+
+// Support `sklt` as a shorthand alias for the default `skillet` command.
+// npm installs typically symlink both `bin.skillet` and `bin.sklt` (via the
+// `bin` field), so the same entry file is reached under either name. Detect
+// which one invoked us and rewrite `cli.name` so help/version output and
+// command examples reflect the invoked name.
+if (process.argv[1]) {
+  const invokedName = process.argv[1].split("/").pop()?.split("\\").pop();
+  if (invokedName === "sklt") {
+    (cli as unknown as { name: string }).name = "sklt";
+  }
+}
 
 if (unknownGlobalFlag) {
   console.error(`Unknown option: ${unknownGlobalFlag}`);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -32,7 +32,7 @@ export async function runInstallCommand(_args: string[], options: RunInstallComm
 
   const manifest = readApmManifest(cwd);
   if (!manifest) {
-    stderr("No apm.yml found. Run `sklt init` to scaffold a project or create apm.yml manually.");
+    stderr("No apm.yml found. Run `skillet init` to scaffold a project or create apm.yml manually.");
     return 1;
   }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -25,7 +25,7 @@ describe("cli", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("Usage:");
-    expect(result.stdout).toContain("$ sklt find [...args]");
+    expect(result.stdout).toContain("$ skillet find [...args]");
   });
 
   test("prints version from environment override", () => {
@@ -37,7 +37,7 @@ describe("cli", () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("sklt/1.2.3");
+    expect(result.stdout).toContain("skillet/1.2.3");
   });
 
   test("returns clear error for unknown command", () => {

--- a/tests/distribution/npm-package.test.ts
+++ b/tests/distribution/npm-package.test.ts
@@ -17,6 +17,6 @@ describe("npm package bundle", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("Usage:");
-    expect(result.stdout).toContain("$ sklt <command> [options]");
+    expect(result.stdout).toContain("$ skillet <command> [options]");
   });
 });


### PR DESCRIPTION
## Summary

- `skillet` is now the default CLI command; `sklt` is a shorthand alias (both point to the same binary).
- `package.json` exposes both `skillet` and `sklt` in `bin`, and the CLI runtime detects which name invoked it and rewrites `cli.name` so help/version output reflects the invoked name.
- Documentation and README rewritten to follow the readme-writing skill pattern (hero block with ASCII banner and badges, install + real session transcript, features as tables, architecture diagram, philosophy, roadmap, docs tables). All examples use `skillet` with `sklt` documented as a shorthand.
- `.gitignore` excludes `.env` (npm publish token) and `.entire/` (opencode session metadata).

## Changes

- `src/cli.ts:135` — `sklt` invocation rewrites `cli.name`.
- `src/commands/install.ts:35` — error message references `skillet init`.
- `package.json:13` — `bin` exposes both `skillet` and `sklt`.
- `.mise.toml:38` — `npm-smoke` exercises both bin entries.
- `scripts/smoke-artifact.ts:36`, `.github/workflows/build-matrix.yaml` — `skillet/` smoke grep.
- `tests/cli.test.ts`, `tests/distribution/npm-package.test.ts` — assertions updated.
- `docs/getting-started.md`, `docs/usage.md`, `docs/distribution/npm.md`, `docs/parity/2026-02-20-vercel-cli-parity.md`, `docs/adr/0001-apm-manifest-compliance.md` — `skillet` default, `sklt` shorthand.
- `README.md` — full rewrite per readme-writing skill.
- `.gitignore` — exclude `.env` and `.entire/`.

## Consequences

- Users with existing scripts using `sklt` continue to work unchanged.
- All examples in README and docs use `skillet`; users can substitute `sklt` everywhere.

## Testing

- `mise run ci` passes: 21 test files, 103 tests pass; npm publish dry-run succeeds.
- Smoke-checked both bin entries manually:
  - `node dist/npm/cli.js --help` shows `$ skillet <command>`
  - Invoking as `/tmp/sklt --help` (after `cp dist/npm/cli.js /tmp/sklt`) shows `$ sklt <command>`

## Follow-ups

- Resolve npm Trusted Publishers OIDC `404 'getskillet is not in this registry'` blocker so v1.1.0 lands on npm via CI (currently using legacy `NPM_TOKEN` fallback locally).
- Local `.env` should be replaced with `direnv` or shell-managed secrets for portability.